### PR TITLE
Forget Last Track Thumbnail in config file

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -30,3 +30,4 @@ sensor:
     - LastTrackDistance     #LastTrack
     - LastTrackAverageSpeed #LastTrack
     - LastTrackRidingtime   #LastTrack
+    - LastTrackThumb        #LastTrack


### PR DESCRIPTION
the feature was developed but the entry in config file was forgot