### PR TITLE
BREAKING: Drop misleading time attribute of the isConnected sensor

### DIFF
--- a/custom_components/niu/sensor.py
+++ b/custom_components/niu/sensor.py
@@ -540,7 +540,6 @@ class NiuSensor(Entity):
                 "longitude": self._data_bridge.dataPos("lng"),
                 "gsm": self._data_bridge.dataMoto("gsm"),
                 "gps": self._data_bridge.dataMoto("gps"),
-                "time": self._data_bridge.dataDist("time"),
             }
 
     def update(self):


### PR DESCRIPTION
The `time` attribute provides the "last track riding time" in a raw format (unix timestamp * additional precision). It doesn't have proper name and the raw data isn't very useful. I would like to drop the attribute to improve the UX.