### PR TITLE
Add additional attributes to the isConnected sensor

### DIFF
--- a/custom_components/niu/sensor.py
+++ b/custom_components/niu/sensor.py
@@ -541,6 +541,10 @@ class NiuSensor(Entity):
                 "gsm": self._data_bridge.dataMoto("gsm"),
                 "gps": self._data_bridge.dataMoto("gps"),
                 "time": self._data_bridge.dataDist("time"),
+                "range": self._data_bridge.dataMoto("estimatedMileage"),
+                "battery": self._data_bridge.dataBat("batteryCharging"),
+                "battery_grade": self._data_bridge.dataBat("gradeBattery"),
+                "centre_ctrl_batt": self._data_bridge.dataMoto("centreCtrlBattery"),
             }
 
     def update(self):


### PR DESCRIPTION
This PR introduces additional attributes to the isConnected sensor which is shown at the HA map:

![map](https://user-images.githubusercontent.com/2735933/122666966-a48bb280-d1b0-11eb-9f3b-31d37b09ddb0.png)
