### PR TITLE
Bump component version

### DIFF
--- a/custom_components/niu/manifest.json
+++ b/custom_components/niu/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/marcelwestrahome/home-assistant-niu-component/issues",
   "requirements": [],
-  "version": "2.0.1"
+  "version": "2.1.3"
 }


### PR DESCRIPTION
It's important to update the `manifest.json` on every release otherwise HACS doesn't pick up the new tag.

Please merge this pull request and prepare another release with version `2.1.3`. 