### PR TITLE
Fix integration not reloading

### DIFF
--- a/custom_components/niu/__init__.py
+++ b/custom_components/niu/__init__.py
@@ -14,9 +14,14 @@ _LOGGER = logging.getLogger(__name__)
 # For your initial PR, limit it to 1 platform.
 PLATFORMS = ["sensor"]
 
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the Niu component."""
+    hass.data.setdefault(DOMAIN, {})
+    return True
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Niu Smart Plug from a config entry."""
+    hass.data[DOMAIN][entry.entry_id] = {}
 
     niu_auth = entry.data.get(CONF_AUTH, None)
     if niu_auth == None:


### PR DESCRIPTION
As noted in #56, the integration cannot be reloaded in Home Assistant and needs a restart to work again. I fixed the setup so reloading should now work.