### PR TITLE
Fix KeyError for scooters without a second battery

### DIFF
--- a/custom_components/niu/api.py
+++ b/custom_components/niu/api.py
@@ -142,8 +142,17 @@ class NiuApi:
     def getDataBatA(self, id_field): 
         return self.dataBat["data"]["batteries"]["compartmentA"][id_field]
 
-    def getDataBatB(self, id_field): 
-        return self.dataBat["data"]["batteries"]["compartmentB"][id_field]
+    def hasSecondBattery(self):
+        try:
+            return "compartmentB" in self.dataBat["data"]["batteries"]
+        except (KeyError, TypeError):
+            return False
+
+    def getDataBatB(self, id_field):
+        try:
+            return self.dataBat["data"]["batteries"]["compartmentB"][id_field]
+        except (KeyError, TypeError):
+            return None
 
     def getDataMoto(self, id_field):
         return self.dataMoto["data"][id_field]

--- a/custom_components/niu/sensor.py
+++ b/custom_components/niu/sensor.py
@@ -123,9 +123,8 @@ class NiuSensor(Entity):
     @property
     def extra_state_attributes(self):
         if self._sensor_grp == SENSOR_TYPE_MOTO and self._id_name == "isConnected":
-            return {
+            attrs = {
                 "bmsId_a": self._api.getDataBatA("bmsId"),
-                "bmsId_b": self._api.getDataBatB("bmsId"),
                 "latitude": self._api.getDataPos("lat"),
                 "longitude": self._api.getDataPos("lng"),
                 "gsm": self._api.getDataMoto("gsm"),
@@ -133,11 +132,14 @@ class NiuSensor(Entity):
                 "time": self._api.getDataDist("time"),
                 "range": self._api.getDataMoto("estimatedMileage"),
                 "battery_a": self._api.getDataBatA("batteryCharging"),
-                "battery_b": self._api.getDataBatB("batteryCharging"),
                 "battery_grade_a": self._api.getDataBatA("gradeBattery"),
-                "battery_grade_b": self._api.getDataBatB("gradeBattery"),
                 "centre_ctrl_batt": self._api.getDataMoto("centreCtrlBattery"),
             }
+            if self._api.hasSecondBattery():
+                attrs["bmsId_b"] = self._api.getDataBatB("bmsId")
+                attrs["battery_b"] = self._api.getDataBatB("batteryCharging")
+                attrs["battery_grade_b"] = self._api.getDataBatB("gradeBattery")
+            return attrs
 
     @Throttle(timedelta(minutes=15))
     async def async_update(self):
@@ -147,7 +149,8 @@ class NiuSensor(Entity):
             
         if self._sensor_grp == SENSOR_TYPE_BAT2:
             await self._hass.async_add_executor_job(self._api.updateBat)
-            self._state = self._api.getDataBatB(self._id_name)
+            if self._api.hasSecondBattery():
+                self._state = self._api.getDataBatB(self._id_name)
 
         elif self._sensor_grp == SENSOR_TYPE_MOTO:
             await self._hass.async_add_executor_job(self._api.updateMoto)


### PR DESCRIPTION
## Summary
- Scooters without a second battery (no `compartmentB` in API response) crash on every state update with a `KeyError` since #66 merged
- `getDataBatB()` now returns `None` instead of raising when `compartmentB` is absent
- `extra_state_attributes` only includes battery B fields when the scooter actually has a second battery
- `async_update` for `SENSOR_TYPE_BAT2` guards against missing second battery data