### PR TITLE
Fix camera setup KeyError and stale attribute references

### DIFF
--- a/custom_components/niu/camera.py
+++ b/custom_components/niu/camera.py
@@ -38,13 +38,15 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         "name": camera_name,
         "still_image_url": "",
         "stream_source": None,
-        "authentication": "basic",
         "username": None,
         "password": None,
-        "limit_refetch_to_url_change": False,
         "content_type": "image/jpeg",
-        "framerate": 2,
-        "verify_ssl": True,
+        "advanced": {
+            "authentication": "basic",
+            "limit_refetch_to_url_change": False,
+            "framerate": 2,
+            "verify_ssl": True,
+        },
     }
     async_add_entities([LastTrackCamera(hass, api, entry, camera_name, camera_name)])
 
@@ -82,9 +84,8 @@ class LastTrackCamera(GenericCamera):
         get_last_track = lambda: self._api.getDataTrack("track_thumb")
         last_track_url = await self.hass.async_add_executor_job(get_last_track)
 
-        if last_track_url == self._last_url and self._previous_image != b"":
-            # The path image is the same as before so the image is the same:
-            return self._previous_image
+        if last_track_url == self._last_url and self._last_image:
+            return self._last_image
 
         try:
             async_client = get_async_client(self.hass, verify_ssl=self.verify_ssl)
@@ -101,5 +102,4 @@ class LastTrackCamera(GenericCamera):
             return self._last_image
 
         self._last_url = last_track_url
-        self._previous_image = self._last_image
         return self._last_image


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'advanced'` during camera platform setup — `GenericCamera.__init__` now expects `authentication`, `framerate`, `verify_ssl`, and `limit_refetch_to_url_change` nested under an `"advanced"` key in the device info dict
- Remove reference to `_previous_image` which no longer exists in the parent `GenericCamera` class, using `_last_image` instead