### PR TITLE
Use Home Assistant locale settings for Niu API requests

### DIFF
--- a/custom_components/niu/api.py
+++ b/custom_components/niu/api.py
@@ -191,10 +191,15 @@ class NiuApi:
         if id_field == "ridingtime":
             return strftime("%H:%M:%S", gmtime(self.dataTrackInfo["data"][0][id_field]))
         if id_field == "track_thumb":
-            thumburl = self.dataTrackInfo["data"][0][id_field].replace(
-                "app-api.niucache.com", "app-api-fk.niu.com"
-            )
-            return thumburl.replace("/track/thumb/", "/track/overseas/thumb/")
+            thumburl = self.dataTrackInfo["data"][0][id_field]
+            # Rewrite domestic CDN URLs to overseas; skip if already overseas
+            if "app-api.niucache.com" in thumburl:
+                thumburl = thumburl.replace(
+                    "app-api.niucache.com", "app-api-fk.niu.com"
+                )
+            if "/track/thumb/" in thumburl and "/track/overseas/thumb/" not in thumburl:
+                thumburl = thumburl.replace("/track/thumb/", "/track/overseas/thumb/")
+            return thumburl
         return self.dataTrackInfo["data"][0][id_field]
 
     def updateBat(self):

--- a/custom_components/niu/api.py
+++ b/custom_components/niu/api.py
@@ -27,7 +27,9 @@ class NiuApi:
     def from_hass(cls, hass, username, password, scooter_id):
         """Create NiuApi with locale settings from Home Assistant config."""
         language = hass.config.language
-        if hass.config.country:
+        # Only append country if language is a bare code (e.g. "en"),
+        # not if it already includes a region (e.g. "en-GB", "zh-Hans")
+        if hass.config.country and "-" not in language:
             language = f"{language}-{hass.config.country}"
         return cls(username, password, scooter_id, language=language, timezone=str(hass.config.time_zone))
 

--- a/custom_components/niu/api.py
+++ b/custom_components/niu/api.py
@@ -11,15 +11,25 @@ from .const import *
 
 
 class NiuApi:
-    def __init__(self, username, password, scooter_id) -> None:
+    def __init__(self, username, password, scooter_id, language="en-US", timezone="UTC") -> None:
         self.username = username
         self.password = password
         self.scooter_id = int(scooter_id)
+        self.language = language
+        self.timezone = timezone
 
         self.dataBat = None
         self.dataMoto = None
         self.dataMotoInfo = None
         self.dataTrackInfo = None
+
+    @classmethod
+    def from_hass(cls, hass, username, password, scooter_id):
+        """Create NiuApi with locale settings from Home Assistant config."""
+        language = hass.config.language
+        if hass.config.country:
+            language = f"{language}-{hass.config.country}"
+        return cls(username, password, scooter_id, language=language, timezone=str(hass.config.time_zone))
 
     def initApi(self):
         self.token = self.get_token()
@@ -79,9 +89,12 @@ class NiuApi:
         url = API_BASE_URL + path
 
         params = {"sn": sn}
+        is_chinese = self.language.startswith("zh")
+        client_id = "Domestic" if is_chinese else "Overseas"
         headers = {
             "token": token,
-            "user-agent": "manager/4.10.4 (android; IN2020 11);lang=zh-CN;clientIdentifier=Domestic;timezone=Asia/Shanghai;model=IN2020;deviceName=IN2020;ostype=android",
+            "Accept-Language": self.language,
+            "user-agent": f"manager/4.10.4 (android; IN2020 11);lang={self.language};clientIdentifier={client_id};timezone={self.timezone};model=IN2020;deviceName=IN2020;ostype=android",
         }
         try:
             r = requests.get(url, headers=headers, params=params)
@@ -102,7 +115,7 @@ class NiuApi:
         sn, token = self.sn, self.token
         url = API_BASE_URL + path
         params = {}
-        headers = {"token": token, "Accept-Language": "en-US"}
+        headers = {"token": token, "Accept-Language": self.language}
         try:
             r = requests.post(url, headers=headers, params=params, data={"sn": sn})
         except ConnectionError:
@@ -118,10 +131,12 @@ class NiuApi:
         sn, token = self.sn, self.token
         url = API_BASE_URL + path
         params = {}
+        is_chinese = self.language.startswith("zh")
+        client_id = "Domestic" if is_chinese else "Overseas"
         headers = {
             "token": token,
-            "Accept-Language": "en-US",
-            "User-Agent": "manager/1.0.0 (identifier);clientIdentifier=identifier",
+            "Accept-Language": self.language,
+            "User-Agent": f"manager/1.0.0 (identifier);clientIdentifier={client_id}",
         }
         try:
             r = requests.post(

--- a/custom_components/niu/camera.py
+++ b/custom_components/niu/camera.py
@@ -29,7 +29,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     password = niu_auth[CONF_PASSWORD]
     scooter_id = niu_auth[CONF_SCOOTER_ID]
 
-    api = NiuApi(username, password, scooter_id)
+    api = NiuApi.from_hass(hass, username, password, scooter_id)
     await hass.async_add_executor_job(api.initApi)
 
     camera_name = api.sensor_prefix + " Last Track Camera"

--- a/custom_components/niu/camera.py
+++ b/custom_components/niu/camera.py
@@ -90,7 +90,8 @@ class LastTrackCamera(GenericCamera):
         try:
             async_client = get_async_client(self.hass, verify_ssl=self.verify_ssl)
             response = await async_client.get(
-                last_track_url, auth=self._auth, timeout=GET_IMAGE_TIMEOUT
+                last_track_url, auth=self._auth, timeout=GET_IMAGE_TIMEOUT,
+                follow_redirects=True,
             )
             response.raise_for_status()
             self._last_image = response.content

--- a/custom_components/niu/config_flow.py
+++ b/custom_components/niu/config_flow.py
@@ -42,7 +42,7 @@ class NiuAuthenticator:
         self.sensors_selected = sensors_selected
 
     async def authenticate(self, hass):
-        api = NiuApi(self.username, self.password, self.scooter_id)
+        api = NiuApi.from_hass(hass, self.username, self.password, self.scooter_id)
         try:
             token = await hass.async_add_executor_job(api.get_token)
             if isinstance(token, bool):

--- a/custom_components/niu/sensor.py
+++ b/custom_components/niu/sensor.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     scooter_id = niu_auth[CONF_SCOOTER_ID]
     sensors_selected = niu_auth[CONF_SENSORS]
 
-    api = NiuApi(username, password, scooter_id)
+    api = NiuApi.from_hass(hass, username, password, scooter_id)
     await hass.async_add_executor_job(api.initApi)
 
     # add sensors


### PR DESCRIPTION

## Problem
The hardcoded Chinese locale in the user-agent header caused the Niu service to treat the account as a Chinese domestic user, which causes the "finished charging" notification to be in Chinese, even if the user does not speak Chinese. This PR fixes this by pulling in locale info from their homeassistant instance and using it in the user-agent string for API requests.

## Summary
- Replaces hardcoded `lang=zh-CN` / `clientIdentifier=Domestic` / `timezone=Asia/Shanghai` in Niu API headers with the user's Home Assistant locale settings (`Settings > System > General`)
- Adds `NiuApi.from_hass()` factory classmethod to read `hass.config.language`, `hass.config.country`, and `hass.config.time_zone`

As a result of these changes, some fixes were needed to maintain last track camera functionality:
- Fixes track thumbnail URL rewriting to handle overseas API responses correctly
- Follows redirects when fetching camera images (Niu CDN may 302)

## Testing

This was tested on my instance with "en-US" and an American locale configured in homeassistant. While the code attempts to account for other locales cleanly, I did not test other languages or locales. No error logs were raised, and charging, then unplugging the charger resulted in an English notification from the iOS Niu app as opposed to the previous Chinese one.
