### PR TITLE
Bump version to 2.1.10 and complete locale fix in get_vehicles_info

### DIFF
--- a/custom_components/niu/api.py
+++ b/custom_components/niu/api.py
@@ -346,22 +346,27 @@ class NiuApi:
             )
         return payload
 
+    def _locale_headers(self) -> dict[str, str]:
+        """Build the locale-aware headers shared by the GET endpoints."""
+        is_chinese = self.language.startswith("zh")
+        client_id = "Domestic" if is_chinese else "Overseas"
+        return {
+            "Accept-Language": self.language,
+            "user-agent": f"manager/4.10.4 (android; IN2020 11);lang={self.language};clientIdentifier={client_id};timezone={self.timezone};model=IN2020;deviceName=IN2020;ostype=android",
+        }
+
     def get_vehicles_info(self, path):
-        return self._authenticated_request("GET", path)
+        return self._authenticated_request(
+            "GET", path, headers=self._locale_headers()
+        )
 
     def get_info(
         self,
         path,
     ):
         params = {"sn": self.sn}
-        is_chinese = self.language.startswith("zh")
-        client_id = "Domestic" if is_chinese else "Overseas"
-        headers = {
-            "Accept-Language": self.language,
-            "user-agent": f"manager/4.10.4 (android; IN2020 11);lang={self.language};clientIdentifier={client_id};timezone={self.timezone};model=IN2020;deviceName=IN2020;ostype=android",
-        }
         return self._authenticated_request(
-            "GET", path, headers=headers, params=params
+            "GET", path, headers=self._locale_headers(), params=params
         )
 
     def post_info(

--- a/custom_components/niu/manifest.json
+++ b/custom_components/niu/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/marcelwestrahome/home-assistant-niu-component/issues",
   "requirements": [],
-  "version": "2.1.8"
+  "version": "2.1.10"
 }

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -361,6 +361,35 @@ class NiuApiTest(unittest.TestCase):
                 with self.assertRaises(api_module.NiuVehicleNotFoundError):
                     self.api.initialize()
 
+    def test_get_vehicles_info_sends_overseas_locale_headers(self) -> None:
+        """The vehicle list request must carry the caller's locale."""
+        self.set_authenticated()
+        api_module.requests.get.return_value = data_response()
+
+        with patch.object(api_module, "monotonic", return_value=0):
+            self.api.get_vehicles_info(api_module.MOTOINFO_LIST_API_URI)
+
+        headers = api_module.requests.get.call_args.kwargs["headers"]
+        self.assertEqual(headers["Accept-Language"], "en-US")
+        self.assertIn("clientIdentifier=Overseas", headers["user-agent"])
+        self.assertIn("lang=en-US", headers["user-agent"])
+
+    def test_get_vehicles_info_sends_domestic_identifier_for_chinese(self) -> None:
+        """A Chinese locale must still be tagged as a domestic client."""
+        self.api = api_module.NiuApi(
+            "user@example.com", "secret", 0, language="zh-CN"
+        )
+        self.api.sn = "TEST-SN"
+        self.set_authenticated()
+        api_module.requests.get.return_value = data_response()
+
+        with patch.object(api_module, "monotonic", return_value=0):
+            self.api.get_vehicles_info(api_module.MOTOINFO_LIST_API_URI)
+
+        headers = api_module.requests.get.call_args.kwargs["headers"]
+        self.assertEqual(headers["Accept-Language"], "zh-CN")
+        self.assertIn("clientIdentifier=Domestic", headers["user-agent"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Since this integration was installed, many non-Chinese users (including myself) started receiving push notifications from the NIU app **in Chinese**. The root cause was hardcoded Chinese locale values in every API request:

```
lang=zh-CN;clientIdentifier=Domestic;timezone=Asia/Shanghai
```

The NIU backend uses `clientIdentifier=Domestic` to tag the account session as a Chinese domestic user and sends push notifications accordingly.

## The fix exists — but hasn't reached HACS users

**PR #69** (merged March 31, 2026) correctly fixed this by reading locale from `hass.config` and sending `clientIdentifier=Overseas` for non-Chinese users. Thank you for merging it.

However, **HACS users are still on the broken version** due to a chain of versioning issues:

| Issue | Effect |
|---|---|
| `manifest.json` was never bumped after PR #69 landed | HACS sees no new version |
| The `2.1.9` GitHub release tag was created on the same day (March 31, 2026) but points to commit `0a9c0e4` — the commit *before* the locale fix | 2.1.9 does not contain the fix |
| `manifest.json` inside the `2.1.9` tag also still reads `2.1.8` | HACS reads `2.1.8` from that tag and never offers an upgrade |

As a result, HACS caps at `2.1.8` and the locale fix is completely unreachable for installed users.

## What this PR does

1. **Bumps `manifest.json` to `2.1.10`** — skipping `2.1.9` to avoid collision with the existing tag that points to an older, unfixed commit.
2. **Completes the locale fix in `get_vehicles_info()`** — this method was the one place missed by PR #69. It was still sending no `Accept-Language` and no `clientIdentifier`, inconsistent with all other API methods.

## Updated after review (@Fitosoft)

The branch has been rebased onto current `master`, which now includes #75. The changes were reworked accordingly:

- `get_vehicles_info()` keeps the shared `_authenticated_request()` path introduced in #75 — token refresh, 401 recovery, timeouts and typed errors all still apply. No direct `requests.get()`, and the token is not added manually (`_perform_request()` already injects it).
- The locale-aware headers previously built inline by `get_info()` are extracted into a small `_locale_headers()` helper, now shared by both GET endpoints. This is the exact drift that caused the original bug, so having one source of truth prevents it from recurring. `post_info()` and `post_info_track()` are untouched — the latter deliberately uses a different User-Agent form.
- Two unit tests were added to `tests/unit/test_api.py` covering precisely the path that #69 missed:
  - `test_get_vehicles_info_sends_overseas_locale_headers` — asserts `Accept-Language: en-US` and `clientIdentifier=Overseas`
  - `test_get_vehicles_info_sends_domestic_identifier_for_chinese` — asserts `Accept-Language: zh-CN` and `clientIdentifier=Domestic`

  Both fail against the pre-fix `get_vehicles_info()` (`KeyError: 'Accept-Language'`) and pass with the change.

The resulting diff against `master` is 3 files / 43 added lines.

## Request to maintainer

Once this PR is merged, please:
1. Create a new **GitHub Release** tagged `2.1.10` pointing to the HEAD of `master`
2. Mark it as the **Latest release**

This will allow HACS users to finally receive the update and stop getting Chinese notifications.

## Testing

`python -m unittest discover -s tests/unit -p "test_*.py" -v` → 39 tests pass (37 existing + 2 new).

After updating to 2.1.10 via HACS and reloading the integration, the NIU app notifications should revert to the user's language within minutes (depending on NIU backend propagation).