### PR TITLE
Improve NIU API session recovery and error handling

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,27 @@
+name: Unit tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests/unit -p "test_*.py" -v

--- a/custom_components/niu/api.py
+++ b/custom_components/niu/api.py
@@ -1,22 +1,98 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 import hashlib
-import json
-
-# from homeassistant.util import Throttle
-from time import gmtime, strftime
+import logging
+from threading import Lock
+from time import gmtime, monotonic, strftime
+from typing import Any
 
 import requests
 
-from .const import *
+from .const import (
+    ACCOUNT_BASE_URL,
+    API_BASE_URL,
+    LOGIN_URI,
+    MOTOR_BATTERY_API_URI,
+    MOTOR_INDEX_API_URI,
+    MOTOINFO_ALL_API_URI,
+    MOTOINFO_LIST_API_URI,
+    TRACK_LIST_API_URI,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+APP_ID = "niu_ktdrr960"
+REQUEST_TIMEOUT = (10, 30)
+TOKEN_REFRESH_MARGIN = 5 * 60
+TOKEN_REFRESH_FALLBACK = 22 * 60 * 60
+
+
+class NiuApiError(Exception):
+    """Base exception for NIU API failures."""
+
+
+class NiuConnectionError(NiuApiError):
+    """The NIU service could not be reached."""
+
+
+class NiuAuthenticationError(NiuApiError):
+    """NIU rejected the current authentication."""
+
+
+class NiuHttpError(NiuApiError):
+    """NIU returned an unexpected HTTP client error."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"NIU API returned HTTP {status_code}")
+        self.status_code = status_code
+
+
+class NiuServerError(NiuApiError):
+    """NIU returned a server-side error."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"NIU API returned server error HTTP {status_code}")
+        self.status_code = status_code
+
+
+class NiuRateLimitError(NiuApiError):
+    """NIU rate-limited the client."""
+
+    def __init__(self, retry_after: int | None) -> None:
+        message = "NIU API rate limit exceeded"
+        if retry_after is not None:
+            message += f"; retry after {retry_after} seconds"
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class NiuResponseError(NiuApiError):
+    """NIU returned an invalid JSON document or an API-level error."""
+
+    def __init__(self, message: str, niu_status: object | None = None) -> None:
+        super().__init__(message)
+        self.niu_status = niu_status
 
 
 class NiuApi:
-    def __init__(self, username, password, scooter_id, language="en-US", timezone="UTC") -> None:
+    def __init__(
+        self,
+        username,
+        password,
+        scooter_id,
+        language="en-US",
+        timezone="UTC",
+    ) -> None:
         self.username = username
         self.password = password
         self.scooter_id = int(scooter_id)
         self.language = language
         self.timezone = timezone
+
+        self.token = None
+        self.refresh_token = None
+        self._token_refresh_at = None
+        self._auth_generation = 0
+        self._auth_lock = Lock()
 
         self.dataBat = None
         self.dataMoto = None
@@ -31,132 +107,265 @@ class NiuApi:
         # not if it already includes a region (e.g. "en-GB", "zh-Hans")
         if hass.config.country and "-" not in language:
             language = f"{language}-{hass.config.country}"
-        return cls(username, password, scooter_id, language=language, timezone=str(hass.config.time_zone))
+        return cls(
+            username,
+            password,
+            scooter_id,
+            language=language,
+            timezone=str(hass.config.time_zone),
+        )
 
     def initApi(self):
-        self.token = self.get_token()
-        api_uri = MOTOINFO_LIST_API_URI
-        self.sn = self.get_vehicles_info(api_uri)["data"]["items"][self.scooter_id][
-            "sn_id"
-        ]
-        self.sensor_prefix = self.get_vehicles_info(api_uri)["data"]["items"][
-            self.scooter_id
-        ]["scooter_name"]
+        self.get_token()
+        vehicles = self.get_vehicles_info(MOTOINFO_LIST_API_URI)
+        try:
+            vehicle = vehicles["data"]["items"][self.scooter_id]
+            self.sn = vehicle["sn_id"]
+            self.sensor_prefix = vehicle["scooter_name"]
+        except (IndexError, KeyError, TypeError) as err:
+            raise NiuResponseError("NIU vehicle list has an unexpected format") from err
         self.updateBat()
         self.updateMoto()
         self.updateMotoInfo()
         self.updateTrackInfo()
 
     def get_token(self):
-        username = self.username
-        password = self.password
+        """Authenticate with username and password and return an access token."""
+        self._password_login()
+        return self.token
 
-        url = ACCOUNT_BASE_URL + LOGIN_URI
-        md5 = hashlib.md5(password.encode("utf-8")).hexdigest()
+    def refresh_access_token(self):
+        """Renew the current access token using NIU's refresh token grant."""
+        if not self.refresh_token:
+            raise NiuAuthenticationError("NIU did not provide a refresh token")
+
         data = {
-            "account": username,
-            "password": md5,
+            "app_id": APP_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": self.refresh_token,
+        }
+        self._store_token(self._request_token(data))
+        return self.token
+
+    def _password_login(self):
+        password_hash = hashlib.md5(self.password.encode("utf-8")).hexdigest()
+        data = {
+            "account": self.username,
+            "password": password_hash,
             "grant_type": "password",
             "scope": "base",
-            "app_id": "niu_ktdrr960",
+            "app_id": APP_ID,
         }
+        self._store_token(self._request_token(data))
+
+    def _request_token(self, data: dict[str, str]) -> dict[str, Any]:
         try:
-            r = requests.post(url, data=data)
-        except BaseException as e:
-            print(e)
-            return False
-        data = json.loads(r.content.decode())
-        return data["data"]["token"]["access_token"]
+            response = requests.post(
+                ACCOUNT_BASE_URL + LOGIN_URI,
+                data=data,
+                timeout=REQUEST_TIMEOUT,
+            )
+        except requests.exceptions.RequestException as err:
+            raise NiuConnectionError("Could not reach NIU authentication service") from err
+
+        payload = self._parse_response(response, authentication_request=True)
+        try:
+            token_data = payload["data"]["token"]
+            access_token = token_data["access_token"]
+        except (KeyError, TypeError) as err:
+            raise NiuAuthenticationError(
+                "NIU authentication response did not contain an access token"
+            ) from err
+        if not isinstance(token_data, dict) or not access_token:
+            raise NiuAuthenticationError("NIU returned an invalid access token")
+        return token_data
+
+    def _store_token(self, token_data: dict[str, Any]) -> None:
+        self.token = token_data["access_token"]
+        refresh_token = token_data.get("refresh_token")
+        if refresh_token:
+            self.refresh_token = refresh_token
+
+        refresh_delay = TOKEN_REFRESH_FALLBACK
+        expires_in = token_data.get("expires_in")
+        if expires_in is not None:
+            try:
+                refresh_delay = max(0, int(expires_in) - TOKEN_REFRESH_MARGIN)
+            except (TypeError, ValueError):
+                _LOGGER.debug("NIU returned an invalid expires_in value")
+        self._token_refresh_at = monotonic() + refresh_delay
+        self._auth_generation += 1
+
+    def _ensure_access_token(self) -> None:
+        if not self.token:
+            with self._auth_lock:
+                if not self.token:
+                    self._password_login()
+            return
+
+        if self._token_refresh_at is None or monotonic() < self._token_refresh_at:
+            return
+
+        with self._auth_lock:
+            if self._token_refresh_at is None or monotonic() < self._token_refresh_at:
+                return
+            try:
+                if self.refresh_token:
+                    self.refresh_access_token()
+                else:
+                    self._password_login()
+            except NiuAuthenticationError:
+                self._password_login()
+            except NiuApiError as err:
+                # The existing token may still be valid. Let the data request decide;
+                # a 401 response will trigger the full recovery path below.
+                _LOGGER.warning("Could not proactively refresh NIU token: %s", err)
+
+    def _recover_authentication(self, attempted_generation: int) -> None:
+        with self._auth_lock:
+            if self._auth_generation != attempted_generation:
+                return
+
+            if self.refresh_token:
+                try:
+                    self.refresh_access_token()
+                    return
+                except NiuApiError as err:
+                    _LOGGER.warning("NIU token refresh failed; logging in again: %s", err)
+
+            self._password_login()
+
+    def _authenticated_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: dict[str, str] | None = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        self._ensure_access_token()
+        attempted_generation = self._auth_generation
+        response = self._perform_request(method, path, headers=headers, **kwargs)
+
+        if response.status_code == 401:
+            self._recover_authentication(attempted_generation)
+            response = self._perform_request(method, path, headers=headers, **kwargs)
+            if response.status_code == 401:
+                raise NiuAuthenticationError(
+                    "NIU rejected authentication after token recovery"
+                )
+
+        return self._parse_response(response)
+
+    def _perform_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: dict[str, str] | None = None,
+        **kwargs,
+    ):
+        request_headers = {**(headers or {}), "token": self.token}
+        request_method = requests.get if method == "GET" else requests.post
+        try:
+            return request_method(
+                API_BASE_URL + path,
+                headers=request_headers,
+                timeout=REQUEST_TIMEOUT,
+                **kwargs,
+            )
+        except requests.exceptions.RequestException as err:
+            raise NiuConnectionError("Could not communicate with NIU API") from err
+
+    @staticmethod
+    def _parse_retry_after(response) -> int | None:
+        value = response.headers.get("Retry-After")
+        if value is None:
+            return None
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return None
+
+    def _parse_response(
+        self, response, *, authentication_request: bool = False
+    ) -> dict[str, Any]:
+        status_code = response.status_code
+        if status_code == 429:
+            raise NiuRateLimitError(self._parse_retry_after(response))
+        if status_code >= 500:
+            raise NiuServerError(status_code)
+        if status_code in (401, 403) or (
+            authentication_request and status_code == 400
+        ):
+            raise NiuAuthenticationError(
+                f"NIU rejected authentication with HTTP {status_code}"
+            )
+        if status_code >= 400:
+            raise NiuHttpError(status_code)
+
+        try:
+            payload = response.json()
+        except (ValueError, requests.exceptions.RequestException) as err:
+            raise NiuResponseError("NIU returned invalid JSON") from err
+        if not isinstance(payload, dict):
+            raise NiuResponseError("NIU returned an unexpected JSON document")
+
+        niu_status = payload.get("status", 0)
+        if niu_status != 0:
+            description = payload.get("desc") or "unknown NIU API error"
+            if authentication_request:
+                raise NiuAuthenticationError(
+                    f"NIU authentication failed with status {niu_status}: {description}"
+                )
+            raise NiuResponseError(
+                f"NIU API returned status {niu_status}: {description}",
+                niu_status=niu_status,
+            )
+        return payload
 
     def get_vehicles_info(self, path):
-        token = self.token
-
-        url = API_BASE_URL + path
-        headers = {"token": token}
-        try:
-            r = requests.get(url, headers=headers, data=[])
-        except ConnectionError:
-            return False
-        if r.status_code != 200:
-            return False
-        data = json.loads(r.content.decode())
-        return data
+        return self._authenticated_request("GET", path)
 
     def get_info(
         self,
         path,
     ):
-        sn = self.sn
-        token = self.token
-        url = API_BASE_URL + path
-
-        params = {"sn": sn}
+        params = {"sn": self.sn}
         is_chinese = self.language.startswith("zh")
         client_id = "Domestic" if is_chinese else "Overseas"
         headers = {
-            "token": token,
             "Accept-Language": self.language,
             "user-agent": f"manager/4.10.4 (android; IN2020 11);lang={self.language};clientIdentifier={client_id};timezone={self.timezone};model=IN2020;deviceName=IN2020;ostype=android",
         }
-        try:
-            r = requests.get(url, headers=headers, params=params)
-
-        except ConnectionError:
-            return False
-        if r.status_code != 200:
-            return False
-        data = json.loads(r.content.decode())
-        if data["status"] != 0:
-            return False
-        return data
+        return self._authenticated_request(
+            "GET", path, headers=headers, params=params
+        )
 
     def post_info(
         self,
         path,
     ):
-        sn, token = self.sn, self.token
-        url = API_BASE_URL + path
-        params = {}
-        headers = {"token": token, "Accept-Language": self.language}
-        try:
-            r = requests.post(url, headers=headers, params=params, data={"sn": sn})
-        except ConnectionError:
-            return False
-        if r.status_code != 200:
-            return False
-        data = json.loads(r.content.decode())
-        if data["status"] != 0:
-            return False
-        return data
+        headers = {"Accept-Language": self.language}
+        return self._authenticated_request(
+            "POST", path, headers=headers, data={"sn": self.sn}
+        )
 
     def post_info_track(self, path):
-        sn, token = self.sn, self.token
-        url = API_BASE_URL + path
-        params = {}
         is_chinese = self.language.startswith("zh")
         client_id = "Domestic" if is_chinese else "Overseas"
         headers = {
-            "token": token,
             "Accept-Language": self.language,
             "User-Agent": f"manager/1.0.0 (identifier);clientIdentifier={client_id}",
         }
-        try:
-            r = requests.post(
-                url,
-                headers=headers,
-                params=params,
-                json={"index": "0", "pagesize": 10, "sn": sn},
-            )
-        except ConnectionError:
-            return False
-        if r.status_code != 200:
-            return False
-        data = json.loads(r.content.decode())
-        if data["status"] != 0:
-            return False
-        return data
+        return self._authenticated_request(
+            "POST",
+            path,
+            headers=headers,
+            json={"index": "0", "pagesize": 10, "sn": self.sn},
+        )
 
-    def getDataBatA(self, id_field): 
+    def getDataBatA(self, id_field):
         return self.dataBat["data"]["batteries"]["compartmentA"][id_field]
 
     def hasSecondBattery(self):

--- a/custom_components/niu/const.py
+++ b/custom_components/niu/const.py
@@ -56,62 +56,6 @@ AVAILABLE_SENSORS = [
     "LastTrackRidingtime",
     "LastTrackThumb",
 ]
-
-
-import voluptuous as vol
-
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-
-# Sensors schemas
-from homeassistant.const import CONF_MONITORED_VARIABLES
-import homeassistant.helpers.config_validation as cv
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_SCOOTER_ID, default=DEFAULT_SCOOTER_ID): cv.positive_int,
-        vol.Optional(CONF_MONITORED_VARIABLES, default=["BatteryCharge"]): vol.All(
-            cv.ensure_list,
-            vol.Length(min=1),
-            [
-                vol.In(
-                    [
-                        "BatteryChargeA",
-                        "BatteryChargeB",
-                        "Isconnected",
-                        "TimesCharged",
-                        "temperatureDesc",
-                        "Temperature",
-                        "BatteryGradeA",
-                        "BatteryGradeB",
-                        "CurrentSpeed",
-                        "ScooterConnected",
-                        "IsCharging",
-                        "IsLocked",
-                        "TimeLeft",
-                        "EstimatedMileage",
-                        "centreCtrlBatt",
-                        "HDOP",
-                        "Longitude",
-                        "Latitude",
-                        "Distance",
-                        "RidingTime",
-                        "totalMileage",
-                        "DaysInUse",
-                        "LastTrackStartTime",
-                        "LastTrackEndTime",
-                        "LastTrackDistance",
-                        "LastTrackAverageSpeed",
-                        "LastTrackRidingtime",
-                        "LastTrackThumb",
-                    ]
-                )
-            ],
-        ),
-    }
-)
-
 SENSOR_TYPES = {
     "BatteryChargeA": [
         "battery_charge_a",

--- a/custom_components/niu/sensor.py
+++ b/custom_components/niu/sensor.py
@@ -5,13 +5,47 @@
 from datetime import timedelta
 import logging
 
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA
+from homeassistant.const import CONF_MONITORED_VARIABLES
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
 from .api import NiuApi
-from .const import *
+from .const import (
+    AVAILABLE_SENSORS,
+    CONF_AUTH,
+    CONF_PASSWORD,
+    CONF_SCOOTER_ID,
+    CONF_SENSORS,
+    CONF_USERNAME,
+    DEFAULT_SCOOTER_ID,
+    SENSOR_TYPES,
+    SENSOR_TYPE_BAT,
+    SENSOR_TYPE_BAT2,
+    SENSOR_TYPE_DIST,
+    SENSOR_TYPE_MOTO,
+    SENSOR_TYPE_OVERALL,
+    SENSOR_TYPE_POS,
+    SENSOR_TYPE_TRACK,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_SCOOTER_ID, default=DEFAULT_SCOOTER_ID): cv.positive_int,
+        vol.Optional(CONF_MONITORED_VARIABLES, default=["BatteryCharge"]): vol.All(
+            cv.ensure_list,
+            vol.Length(min=1),
+            [vol.In(AVAILABLE_SENSORS)],
+        ),
+    }
+)
 
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the NIU integration."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the NIU integration."""

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,329 @@
+"""Unit tests for NIU API authentication and error handling."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import importlib.util
+from pathlib import Path
+import sys
+from threading import Barrier
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+
+class RequestException(Exception):
+    """Base exception raised by the fake requests module."""
+
+
+class Timeout(RequestException):
+    """Request timed out."""
+
+
+class FakeResponse:
+    """Small requests.Response replacement used by the unit tests."""
+
+    def __init__(
+        self,
+        status_code: int,
+        payload: object | None = None,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.headers = headers or {}
+
+    def json(self) -> object:
+        """Return the configured response payload."""
+        if self._payload is None:
+            raise ValueError("response is not valid JSON")
+        return self._payload
+
+
+def _load_api_module():
+    """Load the API module without requiring a Home Assistant installation."""
+    repository_root = Path(__file__).resolve().parents[2]
+    component_root = repository_root / "custom_components"
+    niu_root = component_root / "niu"
+
+    custom_components = types.ModuleType("custom_components")
+    custom_components.__path__ = [str(component_root)]
+    niu_package = types.ModuleType("custom_components.niu")
+    niu_package.__path__ = [str(niu_root)]
+    sys.modules["custom_components"] = custom_components
+    sys.modules["custom_components.niu"] = niu_package
+
+    requests_module = types.ModuleType("requests")
+    requests_module.get = Mock(name="requests.get")
+    requests_module.post = Mock(name="requests.post")
+    requests_module.exceptions = types.SimpleNamespace(
+        RequestException=RequestException,
+    )
+    sys.modules["requests"] = requests_module
+
+    spec = importlib.util.spec_from_file_location(
+        "custom_components.niu.api", niu_root / "api.py"
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load custom_components.niu.api")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+api_module = _load_api_module()
+
+
+def token_response(
+    access_token: str,
+    refresh_token: str = "refresh-token",
+    expires_in: int = 86_400,
+) -> FakeResponse:
+    """Create a successful NIU OAuth token response."""
+    return FakeResponse(
+        200,
+        {
+            "status": 0,
+            "data": {
+                "token": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "expires_in": expires_in,
+                }
+            },
+        },
+    )
+
+
+def data_response(value: str = "ok") -> FakeResponse:
+    """Create a successful NIU data response."""
+    return FakeResponse(200, {"status": 0, "data": {"value": value}})
+
+
+class NiuApiTest(unittest.TestCase):
+    """Verify authentication recovery and robust HTTP handling."""
+
+    def setUp(self) -> None:
+        api_module.requests.get.reset_mock(return_value=True, side_effect=True)
+        api_module.requests.post.reset_mock(return_value=True, side_effect=True)
+        self.api = api_module.NiuApi("user@example.com", "secret", 0)
+        self.api.sn = "TEST-SN"
+
+    def assert_request_timeout(self, request_mock: Mock) -> None:
+        """Assert that a requests call used the integration timeout."""
+        self.assertEqual(
+            request_mock.call_args.kwargs["timeout"], api_module.REQUEST_TIMEOUT
+        )
+
+    def set_authenticated(
+        self,
+        access_token: str = "access",
+        *,
+        refresh_token: str | None = None,
+        refresh_at: float = 1_000,
+    ) -> None:
+        """Configure an access token that remains valid until refresh_at."""
+        self.api.token = access_token
+        self.api.refresh_token = refresh_token
+        self.api._token_refresh_at = refresh_at
+
+    def test_password_login_stores_full_token_and_uses_timeout(self) -> None:
+        """A password login should retain refresh metadata for later renewal."""
+        api_module.requests.post.return_value = token_response("access-1")
+
+        token = self.api.get_token()
+
+        self.assertEqual(token, "access-1")
+        self.assertEqual(self.api.token, "access-1")
+        self.assertEqual(self.api.refresh_token, "refresh-token")
+        self.assert_request_timeout(api_module.requests.post)
+        login_data = api_module.requests.post.call_args.kwargs["data"]
+        self.assertEqual(login_data["grant_type"], "password")
+        self.assertNotEqual(login_data["password"], "secret")
+
+    def test_expiring_token_is_refreshed_before_api_request(self) -> None:
+        """A token at its refresh deadline should be renewed proactively."""
+        self.set_authenticated(
+            "old-access", refresh_token="refresh-token", refresh_at=50
+        )
+        api_module.requests.post.return_value = token_response("new-access")
+        api_module.requests.get.return_value = data_response()
+
+        with patch.object(api_module, "monotonic", return_value=100):
+            result = self.api.get_info(api_module.MOTOR_BATTERY_API_URI)
+
+        self.assertEqual(result["data"]["value"], "ok")
+        self.assertEqual(api_module.requests.post.call_count, 1)
+        self.assertEqual(
+            api_module.requests.get.call_args.kwargs["headers"]["token"],
+            "new-access",
+        )
+
+    def test_401_refreshes_token_and_retries_request_once(self) -> None:
+        """An expired access token should be refreshed and the request retried."""
+        self.set_authenticated("old-access", refresh_token="refresh-token")
+        api_module.requests.get.side_effect = [
+            FakeResponse(401, {"status": 401, "desc": "invalid token"}),
+            data_response("recovered"),
+        ]
+        api_module.requests.post.return_value = token_response("new-access")
+
+        with patch.object(api_module, "monotonic", return_value=0):
+            result = self.api.get_info(api_module.MOTOR_BATTERY_API_URI)
+
+        self.assertEqual(result["data"]["value"], "recovered")
+        self.assertEqual(api_module.requests.get.call_count, 2)
+        self.assertEqual(api_module.requests.post.call_count, 1)
+        retry_headers = api_module.requests.get.call_args_list[1].kwargs["headers"]
+        self.assertEqual(retry_headers["token"], "new-access")
+        refresh_data = api_module.requests.post.call_args.kwargs["data"]
+        self.assertEqual(refresh_data["grant_type"], "refresh_token")
+        self.assertEqual(refresh_data["refresh_token"], "refresh-token")
+
+    def test_401_relogs_in_when_refresh_token_is_rejected(self) -> None:
+        """A rejected refresh token should fall back to a password login."""
+        self.set_authenticated("old-access", refresh_token="invalid-refresh")
+        api_module.requests.get.side_effect = [
+            FakeResponse(401, {"status": 401, "desc": "invalid token"}),
+            data_response("relogged"),
+        ]
+        api_module.requests.post.side_effect = [
+            FakeResponse(401, {"status": 401, "desc": "invalid refresh token"}),
+            token_response("password-access", "password-refresh"),
+        ]
+
+        with (
+            patch.object(api_module, "monotonic", return_value=0),
+            patch.object(api_module._LOGGER, "warning") as warning,
+        ):
+            result = self.api.get_info(api_module.MOTOR_BATTERY_API_URI)
+
+        self.assertEqual(result["data"]["value"], "relogged")
+        self.assertEqual(api_module.requests.post.call_count, 2)
+        warning.assert_called_once()
+        retry_headers = api_module.requests.get.call_args_list[1].kwargs["headers"]
+        self.assertEqual(retry_headers["token"], "password-access")
+
+    def test_second_401_raises_authentication_error_without_looping(self) -> None:
+        """Authentication recovery should retry exactly once."""
+        self.set_authenticated("old-access", refresh_token="refresh-token")
+        api_module.requests.get.side_effect = [
+            FakeResponse(401, {"status": 401}),
+            FakeResponse(401, {"status": 401}),
+        ]
+        api_module.requests.post.return_value = token_response("new-access")
+        with (
+            patch.object(api_module, "monotonic", return_value=0),
+            self.assertRaises(api_module.NiuAuthenticationError),
+        ):
+            self.api.get_info(api_module.MOTOR_BATTERY_API_URI)
+
+        self.assertEqual(api_module.requests.get.call_count, 2)
+        self.assertEqual(api_module.requests.post.call_count, 1)
+
+    def test_concurrent_401_responses_share_one_token_refresh(self) -> None:
+        """Concurrent expired requests should not create a refresh-token storm."""
+        self.set_authenticated("old-access", refresh_token="refresh-token")
+        first_request_barrier = Barrier(2)
+
+        def get_response(*args, **kwargs):
+            if kwargs["headers"]["token"] == "old-access":
+                first_request_barrier.wait(timeout=2)
+                return FakeResponse(401, {"status": 401})
+            return data_response("concurrent-recovery")
+
+        api_module.requests.get.side_effect = get_response
+        api_module.requests.post.return_value = token_response("new-access")
+
+        with (
+            patch.object(api_module, "monotonic", return_value=0),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            results = list(
+                executor.map(
+                    lambda _: self.api.get_info(api_module.MOTOR_BATTERY_API_URI),
+                    range(2),
+                )
+            )
+
+        self.assertEqual(
+            [result["data"]["value"] for result in results],
+            ["concurrent-recovery", "concurrent-recovery"],
+        )
+        self.assertEqual(api_module.requests.get.call_count, 4)
+        self.assertEqual(api_module.requests.post.call_count, 1)
+
+    def test_timeout_raises_connection_error(self) -> None:
+        """Transport timeouts should become a stable integration exception."""
+        self.set_authenticated()
+        api_module.requests.get.side_effect = Timeout("read timed out")
+        with (
+            patch.object(api_module, "monotonic", return_value=0),
+            self.assertRaises(api_module.NiuConnectionError),
+        ):
+            self.api.get_info(api_module.MOTOR_BATTERY_API_URI)
+
+        self.assert_request_timeout(api_module.requests.get)
+
+    def test_429_exposes_retry_after(self) -> None:
+        """Rate-limit responses should retain the server's backoff duration."""
+        self.set_authenticated()
+        api_module.requests.get.return_value = FakeResponse(
+            429,
+            {"status": 429, "desc": "too many requests"},
+            headers={"Retry-After": "120"},
+        )
+        with (
+            patch.object(api_module, "monotonic", return_value=0),
+            self.assertRaises(api_module.NiuRateLimitError) as raised,
+        ):
+            self.api.get_info(api_module.MOTOR_BATTERY_API_URI)
+
+        self.assertEqual(raised.exception.retry_after, 120)
+
+    def test_niu_status_error_raises_response_error(self) -> None:
+        """HTTP 200 responses with a NIU error status should not look successful."""
+        self.set_authenticated()
+        api_module.requests.get.return_value = FakeResponse(
+            200, {"status": 1234, "desc": "temporary NIU failure"}
+        )
+        with (
+            patch.object(api_module, "monotonic", return_value=0),
+            self.assertRaises(api_module.NiuResponseError) as raised,
+        ):
+            self.api.get_info(api_module.MOTOR_BATTERY_API_URI)
+
+        self.assertEqual(raised.exception.niu_status, 1234)
+
+    def test_invalid_json_raises_response_error(self) -> None:
+        """Malformed responses should be reported without leaking parser errors."""
+        self.set_authenticated()
+        api_module.requests.get.return_value = FakeResponse(200, None)
+
+        with (
+            patch.object(api_module, "monotonic", return_value=0),
+            self.assertRaises(api_module.NiuResponseError),
+        ):
+            self.api.get_info(api_module.MOTOR_BATTERY_API_URI)
+
+    def test_failed_update_preserves_last_good_data(self) -> None:
+        """A failed refresh should not replace cached data with False."""
+        previous_data = {"status": 0, "data": {"value": "previous"}}
+        self.api.dataBat = previous_data
+        self.set_authenticated()
+        api_module.requests.get.return_value = FakeResponse(
+            503, {"status": 503, "desc": "service unavailable"}
+        )
+        with (
+            patch.object(api_module, "monotonic", return_value=0),
+            self.assertRaises(api_module.NiuServerError),
+        ):
+            self.api.updateBat()
+
+        self.assertIs(self.api.dataBat, previous_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Describe your changes

This PR makes long-running communication with the NIU API recoverable instead of relying on the access token obtained only during Home Assistant startup.

The previous implementation reused one access token indefinitely, did not consistently bound HTTP calls, and returned ambiguous values for transport and server failures. That could leave the integration unable to recover until Home Assistant was restarted.

This change:

- stores the complete OAuth token response, including refresh-token and expiry metadata;
- refreshes access tokens proactively before their expected expiry;
- retries an API request exactly once after HTTP 401;
- falls back to a password login when the refresh token is missing or rejected;
- serializes concurrent authentication recovery to avoid a refresh/login storm;
- applies explicit connection/read timeouts to NIU HTTP requests;
- introduces typed errors for authentication, connection, rate-limit, server, and malformed-response failures;
- preserves the last valid cached payload when an update fails;
- adds isolated unit tests for authentication recovery and API error behavior; and
- adds a GitHub Actions workflow that runs the unit test suite on pushes and pull requests.

The integration keeps the existing configuration and entity contract. No migration or version-number change is required.

### Stack position

This is the first PR in a four-PR stability stack and has no dependency on another PR in the stack.

### Validation

- `python -m unittest discover -s tests/unit -p "test_*.py" -v`
- 11 API unit tests pass on this branch.
- `git diff --check upstream/master..agent/niu-api-session-stability`
- Authentication recovery is covered for proactive refresh, HTTP 401 retry, rejected refresh tokens, concurrent requests, timeouts, rate limiting, server errors, malformed JSON, and preservation of cached data.

## Issue ticket number and link

- Supports to resolve #56 
- Supports to resolve #64 

Related to:

- #57

The PR intentionally uses `Related to` rather than automatically closing the issues because the later coordinated-polling PR is also relevant to long-term stability.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? No; this changes local integration reliability and adds no telemetry.
- [x] Will this be part of a product update? No separate product announcement is required; the user-facing release note could be: "Improve NIU API session recovery and error handling for long-running Home Assistant installations."
