### PR TITLE
Coordinate NIU API polling and preserve BatteryCharge entities

### DIFF
--- a/custom_components/niu/__init__.py
+++ b/custom_components/niu/__init__.py
@@ -1,4 +1,4 @@
-"""niu component."""
+"""NIU scooter integration."""
 from __future__ import annotations
 
 import logging
@@ -6,44 +6,74 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_AUTH, CONF_SENSORS, DOMAIN
+from .api import NiuApi
+from .const import (
+    CONF_AUTH,
+    CONF_PASSWORD,
+    CONF_SCOOTER_ID,
+    CONF_SENSORS,
+    CONF_USERNAME,
+    DOMAIN,
+)
+from .coordinator import NiuDataUpdateCoordinator, required_sensor_groups
 
 _LOGGER = logging.getLogger(__name__)
 
-# TODO List the platforms that you want to support.
-# For your initial PR, limit it to 1 platform.
-PLATFORMS = ["sensor"]
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Niu component."""
     hass.data.setdefault(DOMAIN, {})
     return True
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Niu Smart Plug from a config entry."""
-    hass.data[DOMAIN][entry.entry_id] = {}
-
-    niu_auth = entry.data.get(CONF_AUTH, None)
-    if niu_auth == None:
+    """Set up NIU from a config entry."""
+    niu_auth = entry.data.get(CONF_AUTH)
+    if niu_auth is None:
         return False
 
-    sensors_selected = niu_auth[CONF_SENSORS]
-    if len(sensors_selected) < 1:
-        _LOGGER.error("You did NOT selected any sensor... cant setup the integration..")
+    sensors_selected = niu_auth.get(CONF_SENSORS, [])
+    if not sensors_selected:
+        _LOGGER.error("No NIU sensors selected; integration cannot be set up")
         return False
 
-    if "LastTrackThumb" in sensors_selected:
-        PLATFORMS.append("camera")
+    api = NiuApi.from_hass(
+        hass,
+        niu_auth[CONF_USERNAME],
+        niu_auth[CONF_PASSWORD],
+        niu_auth[CONF_SCOOTER_ID],
+    )
+    coordinator = NiuDataUpdateCoordinator(
+        hass,
+        entry,
+        api,
+        required_sensor_groups(sensors_selected),
+    )
+    await coordinator.async_config_entry_first_refresh()
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    await hass.config_entries.async_forward_entry_setups(
+        entry, _get_platforms(sensors_selected)
+    )
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    _LOGGER.debug("Unloading NIU config entry")
+    niu_auth = entry.data.get(CONF_AUTH, {})
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        entry, _get_platforms(niu_auth.get(CONF_SENSORS, []))
+    )
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id, None)
 
     return unload_ok
+
+
+def _get_platforms(sensors_selected: list[str]) -> tuple[str, ...]:
+    """Return an immutable, per-entry platform list."""
+    if "LastTrackThumb" in sensors_selected:
+        return ("sensor", "camera")
+    return ("sensor",)

--- a/custom_components/niu/api.py
+++ b/custom_components/niu/api.py
@@ -98,6 +98,8 @@ class NiuApi:
         self.dataMoto = None
         self.dataMotoInfo = None
         self.dataTrackInfo = None
+        self.sn = None
+        self.sensor_prefix = ""
 
     @classmethod
     def from_hass(cls, hass, username, password, scooter_id):
@@ -116,6 +118,15 @@ class NiuApi:
         )
 
     def initApi(self):
+        """Initialize vehicle metadata and fetch all legacy data groups."""
+        self.initialize()
+        self.updateBat()
+        self.updateMoto()
+        self.updateMotoInfo()
+        self.updateTrackInfo()
+
+    def initialize(self):
+        """Authenticate and load vehicle metadata without polling entity data."""
         self.get_token()
         vehicles = self.get_vehicles_info(MOTOINFO_LIST_API_URI)
         try:
@@ -124,10 +135,6 @@ class NiuApi:
             self.sensor_prefix = vehicle["scooter_name"]
         except (IndexError, KeyError, TypeError) as err:
             raise NiuResponseError("NIU vehicle list has an unexpected format") from err
-        self.updateBat()
-        self.updateMoto()
-        self.updateMotoInfo()
-        self.updateTrackInfo()
 
     def get_token(self):
         """Authenticate with username and password and return an access token."""
@@ -366,7 +373,10 @@ class NiuApi:
         )
 
     def getDataBatA(self, id_field):
-        return self.dataBat["data"]["batteries"]["compartmentA"][id_field]
+        try:
+            return self.dataBat["data"]["batteries"]["compartmentA"][id_field]
+        except (KeyError, TypeError):
+            return None
 
     def hasSecondBattery(self):
         try:
@@ -381,26 +391,51 @@ class NiuApi:
             return None
 
     def getDataMoto(self, id_field):
-        return self.dataMoto["data"][id_field]
+        try:
+            return self.dataMoto["data"][id_field]
+        except (KeyError, TypeError):
+            return None
 
     def getDataDist(self, id_field):
-        return self.dataMoto["data"]["lastTrack"][id_field]
+        try:
+            return self.dataMoto["data"]["lastTrack"][id_field]
+        except (KeyError, TypeError):
+            return None
 
     def getDataPos(self, id_field):
-        return self.dataMoto["data"]["postion"][id_field]
+        try:
+            return self.dataMoto["data"]["postion"][id_field]
+        except (KeyError, TypeError):
+            return None
 
     def getDataOverall(self, id_field):
-        return self.dataMotoInfo["data"][id_field]
+        try:
+            return self.dataMotoInfo["data"][id_field]
+        except (KeyError, TypeError):
+            return None
 
     def getDataTrack(self, id_field):
-        if id_field == "startTime" or id_field == "endTime":
-            return datetime.fromtimestamp(
-                (self.dataTrackInfo["data"][0][id_field]) / 1000
-            ).strftime("%Y-%m-%d %H:%M:%S")
+        try:
+            value = self.dataTrackInfo["data"][0][id_field]
+        except (IndexError, KeyError, TypeError):
+            return None
+
+        if id_field in ("startTime", "endTime"):
+            try:
+                return datetime.fromtimestamp(value / 1000).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
+            except (OSError, TypeError, ValueError):
+                return None
         if id_field == "ridingtime":
-            return strftime("%H:%M:%S", gmtime(self.dataTrackInfo["data"][0][id_field]))
+            try:
+                return strftime("%H:%M:%S", gmtime(value))
+            except (OSError, TypeError, ValueError):
+                return None
         if id_field == "track_thumb":
-            thumburl = self.dataTrackInfo["data"][0][id_field]
+            if not isinstance(value, str):
+                return None
+            thumburl = value
             # Rewrite domestic CDN URLs to overseas; skip if already overseas
             if "app-api.niucache.com" in thumburl:
                 thumburl = thumburl.replace(
@@ -409,89 +444,24 @@ class NiuApi:
             if "/track/thumb/" in thumburl and "/track/overseas/thumb/" not in thumburl:
                 thumburl = thumburl.replace("/track/thumb/", "/track/overseas/thumb/")
             return thumburl
-        return self.dataTrackInfo["data"][0][id_field]
+        return value
 
     def updateBat(self):
-        self.dataBat = self.get_info(MOTOR_BATTERY_API_URI)
+        result = self.get_info(MOTOR_BATTERY_API_URI)
+        if result is not None:
+            self.dataBat = result
 
     def updateMoto(self):
-        self.dataMoto = self.get_info(MOTOR_INDEX_API_URI)
+        result = self.get_info(MOTOR_INDEX_API_URI)
+        if result is not None:
+            self.dataMoto = result
 
     def updateMotoInfo(self):
-        self.dataMotoInfo = self.post_info(MOTOINFO_ALL_API_URI)
+        result = self.post_info(MOTOINFO_ALL_API_URI)
+        if result is not None:
+            self.dataMotoInfo = result
 
     def updateTrackInfo(self):
-        self.dataTrackInfo = self.post_info_track(TRACK_LIST_API_URI)
-
-
-"""class NiuDataBridge(object):
-    async def __init__(self, api):
-    #  hass, username, password, country, scooter_id):
-
-        self.api = api
-        # await hass.async_add_executor_job(lambda : NiuDataBridge(username, password, country, scooter_id))
-        # NiuApi(username, password, country, scooter_id)
-        sn, token = self.api.sn, self.api.token
-
-        self._dataBat = None
-        self._dataMoto = None
-        self._dataMotoInfo = None
-        self._dataTrackInfo = None
-        self._sn = sn
-        self._token = token
-
-    def token(self):
-        return self.api.token
-    
-    def sn(self):
-        return self.api.sn
-
-    def sensor_prefix(self):
-        return self.api.sensor_prefix
-
-    def dataBat(self, id_field):
-        return self._dataBat["data"]["batteries"]["compartmentA"][id_field]
-
-    def dataMoto(self, id_field):
-        return self._dataMoto["data"][id_field]
-
-    def dataDist(self, id_field):
-        return self._dataMoto["data"]["lastTrack"][id_field]
-
-    def dataPos(self, id_field):
-        return self._dataMoto["data"]["postion"][id_field]
-
-    def dataOverall(self, id_field):
-        return self._dataMotoInfo["data"][id_field]
-
-    def dataTrack(self, id_field):
-        if id_field == "startTime" or id_field == "endTime":
-            return datetime.fromtimestamp(
-                (self._dataTrackInfo["data"][0][id_field]) / 1000
-            ).strftime("%Y-%m-%d %H:%M:%S")
-        if id_field == "ridingtime":
-            return strftime(
-                "%H:%M:%S", gmtime(self._dataTrackInfo["data"][0][id_field])
-            )
-        if id_field == "track_thumb":
-            thumburl = self._dataTrackInfo["data"][0][id_field].replace(
-                "app-api.niucache.com", "app-api-fk.niu.com"
-            )
-            return thumburl.replace("/track/thumb/", "/track/overseas/thumb/")
-        return self._dataTrackInfo["data"][0][id_field]
-
-    @Throttle(timedelta(seconds=1))
-    def updateBat(self):
-        self._dataBat = self.api.get_info(MOTOR_BATTERY_API_URI)
-
-    @Throttle(timedelta(seconds=1))
-    def updateMoto(self):
-        self._dataMoto = self.api.get_info(MOTOR_INDEX_API_URI)
-
-    @Throttle(timedelta(seconds=1))
-    def updateMotoInfo(self):
-        self._dataMotoInfo = self.api.post_info(MOTOINFO_ALL_API_URI)
-
-    @Throttle(timedelta(seconds=1))
-    def updateTrackInfo(self):
-        self._dataTrackInfo = self.api.post_info_track(TRACK_LIST_API_URI)"""
+        result = self.post_info_track(TRACK_LIST_API_URI)
+        if result is not None:
+            self.dataTrackInfo = result

--- a/custom_components/niu/camera.py
+++ b/custom_components/niu/camera.py
@@ -1,106 +1,73 @@
-"""Last Track for Niu Integration integration.
-    Author: Giovanni P. (@pikka97)
-"""
+"""Last-track camera for the NIU integration."""
+
+from __future__ import annotations
+
 import logging
-from typing import final
 
 import httpx
 
-from homeassistant.components.camera import CameraState
-from homeassistant.components.generic.camera import GenericCamera
+from homeassistant.components.camera import Camera
 from homeassistant.helpers.httpx_client import get_async_client
 
-from .api import NiuApi
-from .const import *
+from .const import DOMAIN
+from .coordinator import NiuDataUpdateCoordinator
+from .entity import NiuCoordinatorEntity
 
 _LOGGER = logging.getLogger(__name__)
 GET_IMAGE_TIMEOUT = 10
 
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
-    niu_auth = entry.data.get(CONF_AUTH, None)
-    if niu_auth == None:
-        _LOGGER.error(
-            "The authenticator of your Niu integration is None.. can not setup the integration..."
-        )
-        return False
-
-    username = niu_auth[CONF_USERNAME]
-    password = niu_auth[CONF_PASSWORD]
-    scooter_id = niu_auth[CONF_SCOOTER_ID]
-
-    api = NiuApi.from_hass(hass, username, password, scooter_id)
-    await hass.async_add_executor_job(api.initApi)
-
-    camera_name = api.sensor_prefix + " Last Track Camera"
-
-    entry = {
-        "name": camera_name,
-        "still_image_url": "",
-        "stream_source": None,
-        "username": None,
-        "password": None,
-        "content_type": "image/jpeg",
-        "advanced": {
-            "authentication": "basic",
-            "limit_refetch_to_url_change": False,
-            "framerate": 2,
-            "verify_ssl": True,
-        },
-    }
-    async_add_entities([LastTrackCamera(hass, api, entry, camera_name, camera_name)])
+    """Set up the last-track camera from a config entry."""
+    coordinator: NiuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([LastTrackCamera(hass, coordinator)])
 
 
-class LastTrackCamera(GenericCamera):
-    def __init__(self, hass, api, device_info, identifier: str, title: str) -> None:
-        self._api = api
-        super().__init__(hass, device_info, identifier, title)
+class LastTrackCamera(NiuCoordinatorEntity, Camera):
+    """Still-image camera showing the latest NIU track thumbnail."""
 
-    @property
-    @final
-    def state(self) -> str:
-        """Return the camera state."""
-        return CameraState.IDLE
+    def __init__(self, hass, coordinator: NiuDataUpdateCoordinator) -> None:
+        NiuCoordinatorEntity.__init__(self, coordinator)
+        Camera.__init__(self)
+        self.hass = hass
+        self._api = coordinator.data
+        self._attr_name = f"{self._api.sensor_prefix} Last Track Camera"
+        # Preserve GenericCamera's previous identifier to avoid a duplicate entity.
+        self._attr_unique_id = self._attr_name
+        self._attr_is_streaming = False
+        self._last_url: str | None = None
+        self._last_image: bytes | None = None
 
     @property
     def is_on(self) -> bool:
-        """Return true if on."""
-        return self._last_image != b""
-
-    @property
-    def device_info(self):
-        device_name = "Niu E-scooter"
-        dev = {
-            "identifiers": {("niu", device_name)},
-            "name": device_name,
-            "manufacturer": "Niu",
-            "model": 1.0,
-        }
-        return dev
+        """Return whether a track thumbnail has been downloaded."""
+        return self._last_image is not None
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
-        get_last_track = lambda: self._api.getDataTrack("track_thumb")
-        last_track_url = await self.hass.async_add_executor_job(get_last_track)
-
-        if last_track_url == self._last_url and self._last_image:
+        """Return the cached image or download it when the URL changed."""
+        last_track_url = self._api.getDataTrack("track_thumb")
+        if not last_track_url:
+            return self._last_image
+        if last_track_url == self._last_url and self._last_image is not None:
             return self._last_image
 
         try:
-            async_client = get_async_client(self.hass, verify_ssl=self.verify_ssl)
-            response = await async_client.get(
-                last_track_url, auth=self._auth, timeout=GET_IMAGE_TIMEOUT,
+            client = get_async_client(self.hass, verify_ssl=True)
+            response = await client.get(
+                last_track_url,
+                timeout=GET_IMAGE_TIMEOUT,
                 follow_redirects=True,
             )
             response.raise_for_status()
-            self._last_image = response.content
         except httpx.TimeoutException:
-            _LOGGER.error("Timeout getting camera image from %s", self._name)
+            _LOGGER.warning("Timeout while fetching NIU last-track image")
             return self._last_image
         except (httpx.RequestError, httpx.HTTPStatusError) as err:
-            _LOGGER.error("Error getting new camera image from %s: %s", self._name, err)
+            _LOGGER.warning("Could not fetch NIU last-track image: %s", err)
             return self._last_image
 
+        self._last_image = response.content
         self._last_url = last_track_url
         return self._last_image

--- a/custom_components/niu/const.py
+++ b/custom_components/niu/const.py
@@ -254,3 +254,15 @@ SENSOR_TYPES = {
         "mdi:map",
     ],
 }
+
+# Names stored by releases before dual-battery support was introduced. Keep
+# their original entity-id suffixes so existing dashboards and history survive
+# a reload, while reusing the current primary-battery definitions.
+SENSOR_TYPES["BatteryCharge"] = [
+    "battery_charge",
+    *SENSOR_TYPES["BatteryChargeA"][1:],
+]
+SENSOR_TYPES["BatteryGrade"] = [
+    "battery_grade",
+    *SENSOR_TYPES["BatteryGradeA"][1:],
+]

--- a/custom_components/niu/coordinator.py
+++ b/custom_components/niu/coordinator.py
@@ -1,0 +1,103 @@
+"""Coordinate NIU API polling for all entities in a config entry."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import NiuApi, NiuApiError, NiuRateLimitError
+from .const import (
+    DOMAIN,
+    SENSOR_TYPE_BAT,
+    SENSOR_TYPE_BAT2,
+    SENSOR_TYPE_DIST,
+    SENSOR_TYPE_MOTO,
+    SENSOR_TYPE_OVERALL,
+    SENSOR_TYPE_POS,
+    SENSOR_TYPE_TRACK,
+    SENSOR_TYPES,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+POLL_INTERVAL = timedelta(seconds=150)
+DEFAULT_RATE_LIMIT_BACKOFF = 300
+MIN_RATE_LIMIT_BACKOFF = 30
+MAX_RATE_LIMIT_BACKOFF = 3600
+
+
+def required_sensor_groups(sensors_selected: list[str]) -> set[str]:
+    """Return the API data groups needed by the selected entities."""
+    return {
+        SENSOR_TYPES[sensor][3]
+        for sensor in sensors_selected
+        if sensor in SENSOR_TYPES
+    }
+
+
+class NiuDataUpdateCoordinator(DataUpdateCoordinator[NiuApi]):
+    """Fetch each required NIU endpoint once per polling cycle."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        api: NiuApi,
+        sensor_groups: set[str],
+    ) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=POLL_INTERVAL,
+        )
+        self.api = api
+        self.sensor_groups = frozenset(sensor_groups)
+        self._initialized = False
+
+    def _sync_update_data(self) -> NiuApi:
+        """Initialize once, then update each required endpoint exactly once."""
+        if not self._initialized:
+            _LOGGER.debug("Initializing shared NIU API client")
+            self.api.initialize()
+            self._initialized = True
+
+        _LOGGER.debug(
+            "Updating NIU data groups: %s", ", ".join(sorted(self.sensor_groups))
+        )
+        if self.sensor_groups & {SENSOR_TYPE_BAT, SENSOR_TYPE_BAT2}:
+            self.api.updateBat()
+        if self.sensor_groups & {
+            SENSOR_TYPE_MOTO,
+            SENSOR_TYPE_POS,
+            SENSOR_TYPE_DIST,
+        }:
+            self.api.updateMoto()
+        if SENSOR_TYPE_OVERALL in self.sensor_groups:
+            self.api.updateMotoInfo()
+        if SENSOR_TYPE_TRACK in self.sensor_groups:
+            self.api.updateTrackInfo()
+        return self.api
+
+    async def _async_update_data(self) -> NiuApi:
+        """Fetch NIU data without blocking Home Assistant's event loop."""
+        try:
+            return await self.hass.async_add_executor_job(self._sync_update_data)
+        except NiuRateLimitError as err:
+            retry_after = err.retry_after or DEFAULT_RATE_LIMIT_BACKOFF
+            retry_after = max(
+                MIN_RATE_LIMIT_BACKOFF,
+                min(retry_after, MAX_RATE_LIMIT_BACKOFF),
+            )
+            raise UpdateFailed(
+                "NIU API rate limit exceeded", retry_after=retry_after
+            ) from err
+        except NiuApiError as err:
+            raise UpdateFailed(f"NIU API update failed: {err}") from err
+        except Exception as err:
+            raise UpdateFailed("Unexpected error while updating NIU data") from err

--- a/custom_components/niu/entity.py
+++ b/custom_components/niu/entity.py
@@ -1,0 +1,23 @@
+"""Shared NIU entity definitions."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import NiuDataUpdateCoordinator
+
+
+class NiuCoordinatorEntity(CoordinatorEntity[NiuDataUpdateCoordinator]):
+    """Base entity attached to a scooter and its shared coordinator."""
+
+    def __init__(self, coordinator: NiuDataUpdateCoordinator) -> None:
+        super().__init__(coordinator)
+        device_name = "Niu E-scooter"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_name)},
+            name=device_name,
+            manufacturer="NIU",
+            model="E-scooter",
+        )

--- a/custom_components/niu/manifest.json
+++ b/custom_components/niu/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "niu",
   "name": "Niu Scooters",
-  "after_dependencies": ["generic"],
+  "after_dependencies": [],
   "codeowners": [
     "@mwestra",
     "@pikka97"

--- a/custom_components/niu/sensor.py
+++ b/custom_components/niu/sensor.py
@@ -1,28 +1,13 @@
-"""
-    Support for Niu Scooters by Marcel Westra.
-    Asynchronous version implementation by Giovanni P. (@pikka97)
-"""
-from datetime import timedelta
-import logging
+"""Sensor entities for NIU scooters."""
 
-import voluptuous as vol
+from __future__ import annotations
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA as SENSOR_PLATFORM_SCHEMA
-from homeassistant.const import CONF_MONITORED_VARIABLES
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
+from homeassistant.components.sensor import SensorEntity
 
-from .api import NiuApi
 from .const import (
-    AVAILABLE_SENSORS,
     CONF_AUTH,
-    CONF_PASSWORD,
-    CONF_SCOOTER_ID,
     CONF_SENSORS,
-    CONF_USERNAME,
-    DEFAULT_SCOOTER_ID,
-    SENSOR_TYPES,
+    DOMAIN,
     SENSOR_TYPE_BAT,
     SENSOR_TYPE_BAT2,
     SENSOR_TYPE_DIST,
@@ -30,178 +15,106 @@ from .const import (
     SENSOR_TYPE_OVERALL,
     SENSOR_TYPE_POS,
     SENSOR_TYPE_TRACK,
+    SENSOR_TYPES,
 )
-
-_LOGGER = logging.getLogger(__name__)
-
-PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_SCOOTER_ID, default=DEFAULT_SCOOTER_ID): cv.positive_int,
-        vol.Optional(CONF_MONITORED_VARIABLES, default=["BatteryCharge"]): vol.All(
-            cv.ensure_list,
-            vol.Length(min=1),
-            [vol.In(AVAILABLE_SENSORS)],
-        ),
-    }
-)
+from .coordinator import NiuDataUpdateCoordinator
+from .entity import NiuCoordinatorEntity
 
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
-    niu_auth = entry.data.get(CONF_AUTH, None)
-    if niu_auth == None:
-        _LOGGER.error(
-            "The authenticator of your Niu integration is None.. can not setup the integration..."
-        )
-        return False
+    """Set up NIU sensors from a config entry."""
+    coordinator: NiuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    sensors_selected = entry.data[CONF_AUTH][CONF_SENSORS]
 
-    username = niu_auth[CONF_USERNAME]
-    password = niu_auth[CONF_PASSWORD]
-    scooter_id = niu_auth[CONF_SCOOTER_ID]
-    sensors_selected = niu_auth[CONF_SENSORS]
-
-    api = NiuApi.from_hass(hass, username, password, scooter_id)
-    await hass.async_add_executor_job(api.initApi)
-
-    # add sensors
-    devices = []
+    entities = []
     for sensor in sensors_selected:
-        if sensor != "LastTrackThumb":
-            sensor_config = SENSOR_TYPES[sensor]
-            devices.append(
-                NiuSensor(
-                    hass,
-                    api,
-                    sensor,
-                    sensor_config[0],
-                    sensor_config[1],
-                    sensor_config[2],
-                    sensor_config[3],
-                    api.sensor_prefix,
-                    sensor_config[4],
-                    api.sn,
-                    sensor_config[5],
-                )
+        if sensor == "LastTrackThumb" or sensor not in SENSOR_TYPES:
+            continue
+        sensor_config = SENSOR_TYPES[sensor]
+        entities.append(
+            NiuSensor(
+                coordinator,
+                sensor,
+                sensor_config[0],
+                sensor_config[1],
+                sensor_config[2],
+                sensor_config[3],
+                sensor_config[4],
+                sensor_config[5],
             )
-        else:
-            # Last Track Thumb sensor will be used as camera... now just skip it
-            pass
+        )
 
-    async_add_entities(devices)
-    return True
+    async_add_entities(entities)
 
 
-class NiuSensor(Entity):
+class NiuSensor(NiuCoordinatorEntity, SensorEntity):
+    """A NIU sensor backed by the config entry's shared coordinator."""
+
     def __init__(
         self,
-        hass,
-        api: NiuApi,
-        name,
-        sensor_id,
-        uom,
-        id_name,
-        sensor_grp,
-        sensor_prefix,
-        device_class,
-        sn,
-        icon,
-    ):
-        self._unique_id = "sensor.niu_scooter_" + sn + "_" + sensor_id
-        self._name = (
-            "NIU Scooter " + sensor_prefix + " " + name
-        )  # Scooter name as sensor prefix
-        self._hass = hass
-        self._uom = uom
+        coordinator: NiuDataUpdateCoordinator,
+        name: str,
+        sensor_id: str,
+        unit: str,
+        data_field: str,
+        sensor_group: str,
+        device_class: str,
+        icon: str,
+    ) -> None:
+        NiuCoordinatorEntity.__init__(self, coordinator)
+        api = coordinator.data
         self._api = api
-        self._device_class = device_class
-        self._id_name = id_name  # info field for parsing the URL
-        self._sensor_grp = sensor_grp  # info field for choosing the right URL
-        self._icon = icon
-        self._state = 0
+        self._data_field = data_field
+        self._sensor_group = sensor_group
+        self._attr_unique_id = f"sensor.niu_scooter_{api.sn}_{sensor_id}"
+        self._attr_name = f"NIU Scooter {api.sensor_prefix} {name}"
+        self._attr_native_unit_of_measurement = unit or None
+        self._attr_device_class = device_class if device_class != "none" else None
+        self._attr_icon = icon
 
     @property
-    def unique_id(self):
-        return self._unique_id
+    def native_value(self):
+        """Return a value from the coordinator's cached API response."""
+        if self._sensor_group == SENSOR_TYPE_BAT:
+            return self._api.getDataBatA(self._data_field)
+        if self._sensor_group == SENSOR_TYPE_BAT2:
+            return self._api.getDataBatB(self._data_field)
+        if self._sensor_group == SENSOR_TYPE_MOTO:
+            return self._api.getDataMoto(self._data_field)
+        if self._sensor_group == SENSOR_TYPE_POS:
+            return self._api.getDataPos(self._data_field)
+        if self._sensor_group == SENSOR_TYPE_DIST:
+            return self._api.getDataDist(self._data_field)
+        if self._sensor_group == SENSOR_TYPE_OVERALL:
+            return self._api.getDataOverall(self._data_field)
+        if self._sensor_group == SENSOR_TYPE_TRACK:
+            return self._api.getDataTrack(self._data_field)
+        return None
 
     @property
-    def name(self):
-        return self._name
+    def extra_state_attributes(self) -> dict | None:
+        """Return diagnostic attributes for the connection sensor."""
+        if self._sensor_group != SENSOR_TYPE_MOTO or self._data_field != "isConnected":
+            return None
 
-    @property
-    def unit_of_measurement(self):
-        return self._uom
-
-    @property
-    def icon(self):
-        return self._icon
-
-    @property
-    def state(self):
-        return self._state
-
-    @property
-    def device_class(self):
-        return self._device_class
-
-    @property
-    def device_info(self):
-        device_name = "Niu E-scooter"
-        return {
-            "identifiers": {("niu", device_name)},
-            "name": device_name,
-            "manufacturer": "Niu",
-            "model": 1.0,
+        attributes = {
+            "bmsId_a": self._api.getDataBatA("bmsId"),
+            "latitude": self._api.getDataPos("lat"),
+            "longitude": self._api.getDataPos("lng"),
+            "gsm": self._api.getDataMoto("gsm"),
+            "gps": self._api.getDataMoto("gps"),
+            "time": self._api.getDataDist("time"),
+            "range": self._api.getDataMoto("estimatedMileage"),
+            "battery_a": self._api.getDataBatA("batteryCharging"),
+            "battery_grade_a": self._api.getDataBatA("gradeBattery"),
+            "centre_ctrl_batt": self._api.getDataMoto("centreCtrlBattery"),
         }
-
-    @property
-    def extra_state_attributes(self):
-        if self._sensor_grp == SENSOR_TYPE_MOTO and self._id_name == "isConnected":
-            attrs = {
-                "bmsId_a": self._api.getDataBatA("bmsId"),
-                "latitude": self._api.getDataPos("lat"),
-                "longitude": self._api.getDataPos("lng"),
-                "gsm": self._api.getDataMoto("gsm"),
-                "gps": self._api.getDataMoto("gps"),
-                "time": self._api.getDataDist("time"),
-                "range": self._api.getDataMoto("estimatedMileage"),
-                "battery_a": self._api.getDataBatA("batteryCharging"),
-                "battery_grade_a": self._api.getDataBatA("gradeBattery"),
-                "centre_ctrl_batt": self._api.getDataMoto("centreCtrlBattery"),
-            }
-            if self._api.hasSecondBattery():
-                attrs["bmsId_b"] = self._api.getDataBatB("bmsId")
-                attrs["battery_b"] = self._api.getDataBatB("batteryCharging")
-                attrs["battery_grade_b"] = self._api.getDataBatB("gradeBattery")
-            return attrs
-
-    @Throttle(timedelta(minutes=15))
-    async def async_update(self):
-        if self._sensor_grp == SENSOR_TYPE_BAT:
-            await self._hass.async_add_executor_job(self._api.updateBat)
-            self._state = self._api.getDataBatA(self._id_name)
-            
-        if self._sensor_grp == SENSOR_TYPE_BAT2:
-            await self._hass.async_add_executor_job(self._api.updateBat)
-            if self._api.hasSecondBattery():
-                self._state = self._api.getDataBatB(self._id_name)
-
-        elif self._sensor_grp == SENSOR_TYPE_MOTO:
-            await self._hass.async_add_executor_job(self._api.updateMoto)
-            self._state = self._api.getDataMoto(self._id_name)
-
-        elif self._sensor_grp == SENSOR_TYPE_POS:
-            await self._hass.async_add_executor_job(self._api.updateMoto)
-            self._state = self._api.getDataPos(self._id_name)
-
-        elif self._sensor_grp == SENSOR_TYPE_DIST:
-            await self._hass.async_add_executor_job(self._api.updateBat)
-            self._state = self._api.getDataDist(self._id_name)
-
-        elif self._sensor_grp == SENSOR_TYPE_OVERALL:
-            await self._hass.async_add_executor_job(self._api.updateMotoInfo)
-            self._state = self._api.getDataOverall(self._id_name)
-
-        elif self._sensor_grp == SENSOR_TYPE_TRACK:
-            await self._hass.async_add_executor_job(self._api.updateTrackInfo)
-            self._state = self._api.getDataTrack(self._id_name)
+        if self._api.hasSecondBattery():
+            attributes.update(
+                {
+                    "bmsId_b": self._api.getDataBatB("bmsId"),
+                    "battery_b": self._api.getDataBatB("batteryCharging"),
+                    "battery_grade_b": self._api.getDataBatB("gradeBattery"),
+                }
+            )
+        return attributes

--- a/tests/unit/ha_stubs.py
+++ b/tests/unit/ha_stubs.py
@@ -1,0 +1,140 @@
+"""Minimal Home Assistant stubs for unit testing the custom integration."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+class DeviceInfo(dict):
+    """Small stand-in for Home Assistant's DeviceInfo mapping."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(kwargs)
+
+
+class UpdateFailed(Exception):
+    """Coordinator update failure carrying an optional retry delay."""
+
+    def __init__(self, message: str = "", *, retry_after: float | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class DataUpdateCoordinator:
+    """Small behavioral subset of Home Assistant's coordinator."""
+
+    @classmethod
+    def __class_getitem__(cls, item):
+        return cls
+
+    def __init__(
+        self, hass, logger, *, config_entry=None, name, update_interval
+    ) -> None:
+        self.hass = hass
+        self.logger = logger
+        self.config_entry = config_entry
+        self.name = name
+        self.update_interval = update_interval
+        self.data = None
+        self.last_update_success = True
+
+    async def async_config_entry_first_refresh(self) -> None:
+        self.data = await self._async_update_data()
+
+
+class CoordinatorEntity:
+    """Small stand-in for CoordinatorEntity."""
+
+    @classmethod
+    def __class_getitem__(cls, item):
+        return cls
+
+    def __init__(self, coordinator) -> None:
+        self.coordinator = coordinator
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success
+
+
+class SensorEntity:
+    """SensorEntity stand-in."""
+
+
+class Camera:
+    """Camera stand-in."""
+
+    def __init__(self) -> None:
+        self.hass = None
+
+
+class TimeoutException(Exception):
+    """httpx timeout stand-in."""
+
+
+class RequestError(Exception):
+    """httpx request error stand-in."""
+
+
+class HTTPStatusError(Exception):
+    """httpx status error stand-in."""
+
+
+def install_homeassistant_stubs() -> None:
+    """Install only the modules imported by the integration under test."""
+    for name in tuple(sys.modules):
+        if name == "homeassistant" or name.startswith("homeassistant."):
+            del sys.modules[name]
+
+    homeassistant = types.ModuleType("homeassistant")
+    homeassistant.__path__ = []
+    components = types.ModuleType("homeassistant.components")
+    components.__path__ = []
+    camera = types.ModuleType("homeassistant.components.camera")
+    camera.Camera = Camera
+    sensor = types.ModuleType("homeassistant.components.sensor")
+    sensor.SensorEntity = SensorEntity
+
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    config_entries.ConfigEntry = type("ConfigEntry", (), {})
+    core = types.ModuleType("homeassistant.core")
+    core.HomeAssistant = type("HomeAssistant", (), {})
+
+    helpers = types.ModuleType("homeassistant.helpers")
+    helpers.__path__ = []
+    device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+    device_registry.DeviceInfo = DeviceInfo
+    httpx_client = types.ModuleType("homeassistant.helpers.httpx_client")
+    httpx_client.get_async_client = lambda hass, verify_ssl=True: None
+    update_coordinator = types.ModuleType("homeassistant.helpers.update_coordinator")
+    update_coordinator.CoordinatorEntity = CoordinatorEntity
+    update_coordinator.DataUpdateCoordinator = DataUpdateCoordinator
+    update_coordinator.UpdateFailed = UpdateFailed
+
+    modules = {
+        "homeassistant": homeassistant,
+        "homeassistant.components": components,
+        "homeassistant.components.camera": camera,
+        "homeassistant.components.sensor": sensor,
+        "homeassistant.config_entries": config_entries,
+        "homeassistant.core": core,
+        "homeassistant.helpers": helpers,
+        "homeassistant.helpers.device_registry": device_registry,
+        "homeassistant.helpers.httpx_client": httpx_client,
+        "homeassistant.helpers.update_coordinator": update_coordinator,
+    }
+    sys.modules.update(modules)
+
+    httpx = types.ModuleType("httpx")
+    httpx.TimeoutException = TimeoutException
+    httpx.RequestError = RequestError
+    httpx.HTTPStatusError = HTTPStatusError
+    sys.modules["httpx"] = httpx
+
+
+def clear_niu_modules() -> None:
+    """Remove cached integration modules so stubs are applied consistently."""
+    for name in tuple(sys.modules):
+        if name == "custom_components.niu" or name.startswith("custom_components.niu."):
+            del sys.modules[name]

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -324,6 +324,21 @@ class NiuApiTest(unittest.TestCase):
 
         self.assertIs(self.api.dataBat, previous_data)
 
+    def test_getters_tolerate_missing_or_malformed_cached_data(self) -> None:
+        """Partial NIU payloads should make entities unavailable, not crash them."""
+        self.api.dataBat = {"data": {"batteries": None}}
+        self.api.dataMoto = {"data": {"lastTrack": None, "postion": None}}
+        self.api.dataMotoInfo = {"data": None}
+        self.api.dataTrackInfo = {"data": []}
+
+        self.assertIsNone(self.api.getDataBatA("batteryCharging"))
+        self.assertIsNone(self.api.getDataBatB("batteryCharging"))
+        self.assertIsNone(self.api.getDataMoto("estimatedMileage"))
+        self.assertIsNone(self.api.getDataDist("distance"))
+        self.assertIsNone(self.api.getDataPos("lat"))
+        self.assertIsNone(self.api.getDataOverall("totalMileage"))
+        self.assertIsNone(self.api.getDataTrack("track_thumb"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_component.py
+++ b/tests/unit/test_component.py
@@ -1,0 +1,124 @@
+"""Unit tests for NIU config-entry lifecycle handling."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from tests.unit.ha_stubs import clear_niu_modules, install_homeassistant_stubs
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+class FakeApi:
+    """API object created once for a config entry."""
+
+    sn = "TEST-SN"
+    sensor_prefix = "MQi"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def initialize(self) -> None:
+        self.calls.append("initialize")
+
+    def updateBat(self) -> None:
+        self.calls.append("battery")
+
+    def updateMoto(self) -> None:
+        self.calls.append("motor")
+
+    def updateMotoInfo(self) -> None:
+        self.calls.append("overall")
+
+    def updateTrackInfo(self) -> None:
+        self.calls.append("track")
+
+
+class FakeConfigEntries:
+    """Record forwarded and unloaded platforms."""
+
+    def __init__(self) -> None:
+        self.forwarded: list[tuple[str, ...]] = []
+        self.unloaded: list[tuple[str, ...]] = []
+
+    async def async_forward_entry_setups(self, entry, platforms) -> None:
+        self.forwarded.append(tuple(platforms))
+
+    async def async_unload_platforms(self, entry, platforms) -> bool:
+        self.unloaded.append(tuple(platforms))
+        return True
+
+
+class FakeHass:
+    """Home Assistant subset used during config-entry setup."""
+
+    def __init__(self) -> None:
+        self.data = {}
+        self.config_entries = FakeConfigEntries()
+        self.config = types.SimpleNamespace(
+            language="de",
+            country="AT",
+            time_zone="Europe/Vienna",
+        )
+
+    async def async_add_executor_job(self, target, *args):
+        return target(*args)
+
+
+class ComponentTest(unittest.IsolatedAsyncioTestCase):
+    """Verify setup and reload use entry-local immutable state."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        sys.path.insert(0, str(REPOSITORY_ROOT))
+
+    def setUp(self) -> None:
+        install_homeassistant_stubs()
+        clear_niu_modules()
+        self.component = importlib.import_module("custom_components.niu")
+        self.const = importlib.import_module("custom_components.niu.const")
+
+    async def test_setup_and_reload_share_one_api_and_stable_platforms(self) -> None:
+        """Reloading must not retain or duplicate a mutable platform list."""
+        auth = {
+            self.const.CONF_USERNAME: "user@example.com",
+            self.const.CONF_PASSWORD: "secret",
+            self.const.CONF_SCOOTER_ID: 0,
+            self.const.CONF_SENSORS: ["BatteryChargeA", "LastTrackThumb"],
+        }
+        entry = types.SimpleNamespace(
+            entry_id="entry-1", data={self.const.CONF_AUTH: auth}
+        )
+        hass = FakeHass()
+        first_api = FakeApi()
+        second_api = FakeApi()
+
+        with patch.object(
+            self.component.NiuApi,
+            "from_hass",
+            side_effect=[first_api, second_api],
+        ) as from_hass:
+            self.assertTrue(await self.component.async_setup_entry(hass, entry))
+            first_coordinator = hass.data[self.const.DOMAIN][entry.entry_id]
+            self.assertIs(first_coordinator.data, first_api)
+            self.assertTrue(await self.component.async_unload_entry(hass, entry))
+            self.assertTrue(await self.component.async_setup_entry(hass, entry))
+
+        self.assertEqual(from_hass.call_count, 2)
+        self.assertEqual(first_api.calls, ["initialize", "battery", "track"])
+        self.assertEqual(second_api.calls, ["initialize", "battery", "track"])
+        self.assertEqual(
+            hass.config_entries.forwarded,
+            [("sensor", "camera"), ("sensor", "camera")],
+        )
+        self.assertEqual(hass.config_entries.unloaded, [("sensor", "camera")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1,0 +1,124 @@
+"""Unit tests for coordinated NIU polling."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+import unittest
+
+from tests.unit.ha_stubs import clear_niu_modules, install_homeassistant_stubs
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+class FakeHass:
+    """Home Assistant subset used by the coordinator."""
+
+    async def async_add_executor_job(self, target, *args):
+        return target(*args)
+
+
+class FakeApi:
+    """Record all synchronous API operations."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def initialize(self) -> None:
+        self.calls.append("initialize")
+
+    def updateBat(self) -> None:
+        self.calls.append("battery")
+
+    def updateMoto(self) -> None:
+        self.calls.append("motor")
+
+    def updateMotoInfo(self) -> None:
+        self.calls.append("overall")
+
+    def updateTrackInfo(self) -> None:
+        self.calls.append("track")
+
+
+class CoordinatorTest(unittest.IsolatedAsyncioTestCase):
+    """Verify one shared and selective polling cycle."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        sys.path.insert(0, str(REPOSITORY_ROOT))
+
+    def setUp(self) -> None:
+        install_homeassistant_stubs()
+        clear_niu_modules()
+        self.coordinator_module = importlib.import_module(
+            "custom_components.niu.coordinator"
+        )
+        self.const = importlib.import_module("custom_components.niu.const")
+
+    async def test_first_refresh_initializes_once_and_deduplicates_endpoints(
+        self,
+    ) -> None:
+        """Several entity groups sharing an endpoint must produce one request."""
+        api = FakeApi()
+        coordinator = self.coordinator_module.NiuDataUpdateCoordinator(
+            FakeHass(),
+            None,
+            api,
+            {
+                self.const.SENSOR_TYPE_BAT,
+                self.const.SENSOR_TYPE_BAT2,
+                self.const.SENSOR_TYPE_MOTO,
+                self.const.SENSOR_TYPE_POS,
+                self.const.SENSOR_TYPE_DIST,
+                self.const.SENSOR_TYPE_TRACK,
+            },
+        )
+
+        await coordinator.async_config_entry_first_refresh()
+        await coordinator._async_update_data()
+
+        self.assertEqual(
+            api.calls,
+            [
+                "initialize",
+                "battery",
+                "motor",
+                "track",
+                "battery",
+                "motor",
+                "track",
+            ],
+        )
+        self.assertIs(coordinator.data, api)
+
+    async def test_rate_limit_is_forwarded_as_coordinator_backoff(self) -> None:
+        """A Retry-After header should control the next coordinator attempt."""
+        api_module = importlib.import_module("custom_components.niu.api")
+
+        class RateLimitedApi(FakeApi):
+            def updateBat(self) -> None:
+                raise api_module.NiuRateLimitError(420)
+
+        coordinator = self.coordinator_module.NiuDataUpdateCoordinator(
+            FakeHass(), None, RateLimitedApi(), {self.const.SENSOR_TYPE_BAT}
+        )
+        coordinator._initialized = True
+
+        with self.assertRaises(self.coordinator_module.UpdateFailed) as raised:
+            await coordinator._async_update_data()
+
+        self.assertEqual(raised.exception.retry_after, 420)
+
+    def test_legacy_battery_sensors_still_require_battery_endpoint(self) -> None:
+        """Existing entries with pre-dual-battery names must keep polling."""
+        groups = self.coordinator_module.required_sensor_groups(
+            ["BatteryCharge", "BatteryGrade"]
+        )
+
+        self.assertEqual(groups, {self.const.SENSOR_TYPE_BAT})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -1,0 +1,208 @@
+"""Unit tests for coordinator-backed NIU entities."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from tests.unit.ha_stubs import clear_niu_modules, install_homeassistant_stubs
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+class FakeApi:
+    """Cached API data exposed to entities."""
+
+    sn = "TEST-SN"
+    sensor_prefix = "MQi"
+
+    def __init__(self) -> None:
+        self.updateBat = Mock()
+        self.updateMoto = Mock()
+
+    def getDataBatA(self, field):
+        return {"batteryCharging": 81}.get(field)
+
+    def getDataBatB(self, field):
+        return {"batteryCharging": 74}.get(field)
+
+    def getDataMoto(self, field):
+        return None
+
+    def getDataPos(self, field):
+        return None
+
+    def getDataDist(self, field):
+        return None
+
+    def getDataOverall(self, field):
+        return None
+
+    def getDataTrack(self, field):
+        return None
+
+    def hasSecondBattery(self):
+        return True
+
+
+class FakeCoordinator:
+    """Coordinator carrying one shared API object."""
+
+    def __init__(self, api) -> None:
+        self.data = api
+        self.last_update_success = True
+
+
+class FakeResponse:
+    """Successful still-image response."""
+
+    content = b"image-bytes"
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class FakeClient:
+    """Record image downloads."""
+
+    def __init__(self) -> None:
+        self.get = AsyncMock(return_value=FakeResponse())
+
+
+class EntityTest(unittest.IsolatedAsyncioTestCase):
+    """Verify entities consume only coordinator-cached state."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        sys.path.insert(0, str(REPOSITORY_ROOT))
+
+    def setUp(self) -> None:
+        install_homeassistant_stubs()
+        clear_niu_modules()
+        self.const = importlib.import_module("custom_components.niu.const")
+        self.sensor_module = importlib.import_module("custom_components.niu.sensor")
+        self.camera_module = importlib.import_module("custom_components.niu.camera")
+        self.api = FakeApi()
+        self.coordinator = FakeCoordinator(self.api)
+
+    def test_sensor_reads_cache_without_triggering_api_update(self) -> None:
+        """Reading multiple sensors must not cause duplicate network requests."""
+        sensor_a = self.sensor_module.NiuSensor(
+            self.coordinator,
+            "BatteryChargeA",
+            "battery_charge_a",
+            "%",
+            "batteryCharging",
+            self.const.SENSOR_TYPE_BAT,
+            "battery",
+            "mdi:battery",
+        )
+        sensor_b = self.sensor_module.NiuSensor(
+            self.coordinator,
+            "BatteryChargeB",
+            "battery_charge_b",
+            "%",
+            "batteryCharging",
+            self.const.SENSOR_TYPE_BAT2,
+            "battery",
+            "mdi:battery",
+        )
+
+        self.assertEqual(sensor_a.native_value, 81)
+        self.assertEqual(sensor_b.native_value, 74)
+        self.api.updateBat.assert_not_called()
+        self.assertEqual(
+            sensor_a._attr_device_info["identifiers"],
+            {("niu", "Niu E-scooter")},
+        )
+        self.assertIsInstance(sensor_a._attr_device_info["model"], str)
+        self.assertEqual(sensor_a._attr_device_info, sensor_b._attr_device_info)
+
+    async def test_legacy_battery_entities_keep_names_and_unique_ids(self) -> None:
+        """Reloading an old config entry must restore its original entities."""
+        entry = types.SimpleNamespace(
+            entry_id="entry-1",
+            data={
+                self.const.CONF_AUTH: {
+                    self.const.CONF_SENSORS: ["BatteryCharge", "BatteryGrade"]
+                }
+            },
+        )
+        hass = types.SimpleNamespace(
+            data={self.const.DOMAIN: {entry.entry_id: self.coordinator}}
+        )
+        async_add_entities = Mock()
+
+        await self.sensor_module.async_setup_entry(hass, entry, async_add_entities)
+
+        entities = async_add_entities.call_args.args[0]
+        self.assertEqual(
+            [entity._attr_name for entity in entities],
+            ["NIU Scooter MQi BatteryCharge", "NIU Scooter MQi BatteryGrade"],
+        )
+        self.assertEqual(
+            [entity._attr_unique_id for entity in entities],
+            [
+                "sensor.niu_scooter_TEST-SN_battery_charge",
+                "sensor.niu_scooter_TEST-SN_battery_grade",
+            ],
+        )
+        self.assertEqual(entities[0].native_value, 81)
+
+    async def test_camera_uses_plain_camera_and_caches_unchanged_url(self) -> None:
+        """The NIU camera should download a thumbnail only when its URL changes."""
+        self.api.getDataTrack = Mock(return_value="https://example.test/track.jpg")
+        hass = types.SimpleNamespace()
+        client = FakeClient()
+        camera = self.camera_module.LastTrackCamera(hass, self.coordinator)
+
+        with patch.object(self.camera_module, "get_async_client", return_value=client):
+            first = await camera.async_camera_image()
+            second = await camera.async_camera_image()
+
+        self.assertEqual(first, b"image-bytes")
+        self.assertEqual(second, b"image-bytes")
+        self.assertEqual(client.get.call_count, 1)
+        self.assertEqual(camera._attr_unique_id, "MQi Last Track Camera")
+        self.assertEqual(
+            camera._attr_device_info["identifiers"],
+            {("niu", "Niu E-scooter")},
+        )
+        self.assertIsInstance(camera._attr_device_info["model"], str)
+
+    async def test_camera_preserves_cached_image_after_timeout(self) -> None:
+        """A transient image failure must not discard the last valid thumbnail."""
+        self.api.getDataTrack = Mock(
+            side_effect=[
+                "https://example.test/first.jpg",
+                "https://example.test/second.jpg",
+            ]
+        )
+        hass = types.SimpleNamespace()
+        client = FakeClient()
+        client.get.side_effect = [
+            FakeResponse(),
+            self.camera_module.httpx.TimeoutException("timed out"),
+        ]
+        camera = self.camera_module.LastTrackCamera(hass, self.coordinator)
+
+        with (
+            patch.object(self.camera_module, "get_async_client", return_value=client),
+            patch.object(self.camera_module._LOGGER, "warning") as warning,
+        ):
+            first = await camera.async_camera_image()
+            after_timeout = await camera.async_camera_image()
+
+        self.assertEqual(first, b"image-bytes")
+        self.assertEqual(after_timeout, b"image-bytes")
+        self.assertEqual(client.get.call_count, 2)
+        warning.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Describe your changes

> [!NOTE]
> #75 has been merged. This branch was rebased onto `master` at `57a6c99` and now contains exactly one commit relative to the current `master`.

This PR replaces entity-driven NIU polling with one shared Home Assistant `DataUpdateCoordinator` per config entry.

Previously, sensor and camera setup paths could update the same NIU resources independently. That multiplied requests, made reload behavior harder to reason about, and increased the chance of hitting undocumented NIU API limits during long-running Home Assistant operation.

This change:

- creates one coordinator and one NIU API instance for each config entry;
- derives the required NIU datasets from the configured sensor selection;
- batches each refresh and de-duplicates shared API endpoints;
- replaces per-entity 15-minute throttling with a shared 150-second polling cycle that fetches each required API data group once;
- forwards NIU `Retry-After` information into coordinator backoff behavior;
- exposes cached coordinator data to entities without network access from property reads;
- preserves the last successful values across transient update failures;
- stores runtime state per config entry so unload and reload create a clean coordinator lifecycle;
- avoids mutating the configured platform list during repeated reloads;
- converts device model values to strings for Home Assistant device-registry compatibility; and
- restores the legacy `BatteryCharge` entity name and unique ID for existing installations while retaining dual-battery support.

The BatteryCharge compatibility handling is intentionally non-breaking: installations created before the dual-battery sensor change regain their existing entity instead of receiving a renamed replacement.

### Stack position

1. #75 ? API session recovery and robust HTTP errors
2. **This PR #76 coordinated polling and legacy BatteryCharge compatibility**
3. Follow-up PR #77 IsCharging device-class compatibility
4. Follow-up PR #78 last-track camera rendering

### Validation

- `python -m unittest discover -s tests/unit -p "test_*.py" -v`
- 20 cumulative unit tests pass on this branch.
- The incremental diff contains one commit relative to #75.
- Home Assistant was restarted with this code, and the integration was reloaded repeatedly without duplicate setup failures.
- Debug logging confirmed subsequent scheduled updates at the configured 150-second interval.
- The legacy BatteryCharge entity reappeared and continued reporting data in the practical Home Assistant test.
- Tests cover endpoint de-duplication, shared API/coordinator lifecycle, reload behavior, rate-limit backoff, cached entity reads, image caching, and legacy battery identity.

## Issue ticket number and link

- Builds on #75, which has been merged into `master`.
- Resolves #73 
- Supports to resolve #56 
- Supports to resolve #64 

Related to:

- #57 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? No; request de-duplication and coordinator state are validated locally without telemetry.
- [x] Will this be part of a product update? No separate product announcement is required; the user-facing release note could be: "Coordinate NIU polling to reduce duplicate API requests and preserve existing BatteryCharge entities."