### PR TITLE
Correct IsCharging sensor metadata without breaking entity identity

### DIFF
--- a/custom_components/niu/const.py
+++ b/custom_components/niu/const.py
@@ -142,7 +142,7 @@ SENSOR_TYPES = {
         "",
         "isCharging",
         SENSOR_TYPE_MOTO,
-        "power",
+        "none",
         "mdi:battery-charging",
     ],
     "IsLocked": ["is_locked", "", "lockStatus", SENSOR_TYPE_MOTO, "lock", "mdi:lock"],

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -154,6 +154,26 @@ class EntityTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(entities[0].native_value, 81)
 
+    def test_is_charging_keeps_identity_without_power_device_class(self) -> None:
+        """A boolean charging state must not claim to be power measured in watts."""
+        sensor_config = self.const.SENSOR_TYPES["IsCharging"]
+        sensor = self.sensor_module.NiuSensor(
+            self.coordinator,
+            "IsCharging",
+            sensor_config[0],
+            sensor_config[1],
+            sensor_config[2],
+            sensor_config[3],
+            sensor_config[4],
+            sensor_config[5],
+        )
+
+        self.assertEqual(
+            sensor._attr_unique_id, "sensor.niu_scooter_TEST-SN_is_charging"
+        )
+        self.assertIsNone(sensor._attr_device_class)
+        self.assertIsNone(sensor._attr_native_unit_of_measurement)
+
     async def test_camera_uses_plain_camera_and_caches_unchanged_url(self) -> None:
         """The NIU camera should download a thumbnail only when its URL changes."""
         self.api.getDataTrack = Mock(return_value="https://example.test/track.jpg")


### PR DESCRIPTION
## Describe your changes

> [!IMPORTANT]
> This is a stacked PR. It depends on #76 and should be merged after #76.
>
> The branch contains exactly one additional commit relative to `fix/coordinated-api-polling`. Because this PR intentionally targets `master`, GitHub will also show the changes inherited from #75 and #76 until those PRs are merged.

This PR fixes the metadata of the existing `IsCharging` sensor without changing its entity identity or its NIU value source.

`IsCharging` represents a charging state, but it was declared with Home Assistant's `power` device class. A power sensor is expected to expose a numerical power measurement with a compatible unit such as watts; the NIU value is instead a state flag. The mismatched metadata can produce invalid semantics and compatibility warnings in newer Home Assistant releases.

This change:

- removes the incorrect `power` device class from `IsCharging`;
- leaves the entity name, unique ID, icon, source field, and reported state untouched;
- avoids introducing a unit of measurement for a state flag; and
- adds a regression test that proves the entity identity remains stable while the incompatible metadata is absent.

The fix is intentionally non-breaking. Existing dashboards, entity references, history, and automations continue to use the same entity and unique ID.

### Stack position

1. #75 ? API session recovery and robust HTTP errors
2. #76 ? coordinated polling and legacy BatteryCharge compatibility
3. **This PR #77 IsCharging metadata compatibility**
4. Sibling follow-up PR #78 last-track camera rendering (also based directly on #76)

### Validation

- `python -m unittest discover -s tests/unit -p "test_*.py" -v`
- 21 cumulative unit tests pass on this branch.
- The incremental diff is one commit and changes only `custom_components/niu/const.py` plus its focused regression test.
- Practical Home Assistant testing confirmed that the IsCharging fix works and that the existing entity remains available.

## Issue ticket number and link

Depends on #76 ? please merge #76 first. This transitively depends on #75.

There is no dedicated upstream issue for this compatibility warning; it was identified and reproduced during Home Assistant testing of the stability stack.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? No; this is a deterministic entity-metadata correction.
- [x] Will this be part of a product update? No separate product announcement is required; the user-facing release note could be: "Correct IsCharging sensor metadata while preserving existing entity IDs."
