### PR TITLE
Fix NIU last-track camera rendering and thumbnail fallback

### DIFF
--- a/custom_components/niu/camera.py
+++ b/custom_components/niu/camera.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
+from time import monotonic
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
@@ -14,7 +18,102 @@ from .coordinator import NiuDataUpdateCoordinator
 from .entity import NiuCoordinatorEntity
 
 _LOGGER = logging.getLogger(__name__)
-GET_IMAGE_TIMEOUT = 10
+GET_IMAGE_TIMEOUT = 5
+GET_IMAGE_TOTAL_TIMEOUT = 8
+IMAGE_FAILURE_RETRY_INTERVAL = 60
+
+
+def _detect_image_content_type(content: bytes) -> str | None:
+    """Return the media type identified from common image signatures."""
+    if content.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if content.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if content.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if content.startswith(b"RIFF") and content[8:12] == b"WEBP":
+        return "image/webp"
+    if content.startswith(b"BM"):
+        return "image/bmp"
+
+    stripped = content.lstrip()
+    if stripped.startswith(b"<svg") or (
+        stripped.startswith(b"<?xml") and b"<svg" in stripped[:512]
+    ):
+        return "image/svg+xml"
+    return None
+
+
+def _thumbnail_url_candidates(url: str) -> list[str]:
+    """Return known NIU thumbnail URL variants without duplicates."""
+    parsed = urlsplit(url)
+    if not any(
+        path in parsed.path for path in ("/track/thumb/", "/track/overseas/thumb/")
+    ):
+        return [url]
+
+    fk_gateway = parsed.hostname == "s.niucache.com" and parsed.path.startswith(
+        "/app-api-fk/"
+    )
+    direct_path = parsed.path.removeprefix("/app-api-fk") if fk_gateway else parsed.path
+
+    domestic_path = direct_path.replace("/track/overseas/thumb/", "/track/thumb/")
+    overseas_path = domestic_path.replace("/track/thumb/", "/track/overseas/thumb/")
+    if fk_gateway:
+        gateway_domestic_path = parsed.path.replace(
+            "/track/overseas/thumb/", "/track/thumb/"
+        )
+        variants = [
+            urlunsplit(parsed._replace(path=gateway_domestic_path)),
+            url,
+            urlunsplit(
+                parsed._replace(netloc="app-api-fk.niu.com", path=domestic_path)
+            ),
+            urlunsplit(
+                parsed._replace(netloc="app-api-fk.niu.com", path=overseas_path)
+            ),
+        ]
+    else:
+        variants = [
+            url,
+            urlunsplit(
+                parsed._replace(netloc="app-api.niucache.com", path=domestic_path)
+            ),
+            urlunsplit(
+                parsed._replace(netloc="app-api-fk.niu.com", path=overseas_path)
+            ),
+            urlunsplit(
+                parsed._replace(netloc="app-api-fk.niu.com", path=domestic_path)
+            ),
+            urlunsplit(parsed._replace(netloc="app-api.niu.com", path=domestic_path)),
+        ]
+    return list(dict.fromkeys(variants))
+
+
+def _thumbnail_path_type(url: str) -> str:
+    """Describe a thumbnail path without exposing its ride identifier."""
+    path = urlsplit(url).path
+    if "/track/overseas/thumb/" in path:
+        return "overseas"
+    if "/track/thumb/" in path:
+        return "domestic"
+    return "other"
+
+
+def _invalid_image_description(content: bytes) -> str:
+    """Describe a NIU JSON error without logging the full response body."""
+    try:
+        payload = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return f"unrecognized {len(content)}-byte response"
+
+    if not isinstance(payload, dict):
+        return "JSON response"
+    description = payload.get("desc")
+    status = payload.get("status")
+    if description:
+        return f"NIU status {status}: {description}"
+    return "JSON response"
 
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
@@ -37,11 +136,8 @@ class LastTrackCamera(NiuCoordinatorEntity, Camera):
         self._attr_is_streaming = False
         self._last_url: str | None = None
         self._last_image: bytes | None = None
-
-    @property
-    def is_on(self) -> bool:
-        """Return whether a track thumbnail has been downloaded."""
-        return self._last_image is not None
+        self._failed_url: str | None = None
+        self._failure_retry_at = 0.0
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
@@ -49,25 +145,109 @@ class LastTrackCamera(NiuCoordinatorEntity, Camera):
         """Return the cached image or download it when the URL changed."""
         last_track_url = self._api.getDataTrack("track_thumb")
         if not last_track_url:
+            _LOGGER.debug("No NIU last-track thumbnail URL available")
             return self._last_image
         if last_track_url == self._last_url and self._last_image is not None:
             return self._last_image
+        if last_track_url == self._failed_url and monotonic() < self._failure_retry_at:
+            return self._last_image
 
+        candidates = _thumbnail_url_candidates(last_track_url)
+        _LOGGER.debug(
+            "Trying %d NIU last-track thumbnail candidate(s) "
+            "(source host: %s, path type: %s)",
+            len(candidates),
+            urlsplit(last_track_url).hostname or "relative",
+            _thumbnail_path_type(last_track_url),
+        )
+        client = get_async_client(self.hass, verify_ssl=True)
         try:
-            client = get_async_client(self.hass, verify_ssl=True)
-            response = await client.get(
-                last_track_url,
-                timeout=GET_IMAGE_TIMEOUT,
-                follow_redirects=True,
-            )
-            response.raise_for_status()
-        except httpx.TimeoutException:
-            _LOGGER.warning("Timeout while fetching NIU last-track image")
-            return self._last_image
-        except (httpx.RequestError, httpx.HTTPStatusError) as err:
-            _LOGGER.warning("Could not fetch NIU last-track image: %s", err)
-            return self._last_image
+            async with asyncio.timeout(GET_IMAGE_TOTAL_TIMEOUT):
+                for candidate_url in candidates:
+                    candidate_host = urlsplit(candidate_url).hostname or "relative"
+                    candidate_path_type = _thumbnail_path_type(candidate_url)
+                    try:
+                        response = await client.get(
+                            candidate_url,
+                            timeout=GET_IMAGE_TIMEOUT,
+                            follow_redirects=True,
+                        )
+                        response.raise_for_status()
+                    except httpx.TimeoutException:
+                        _LOGGER.warning(
+                            "Timeout while fetching NIU last-track image candidate "
+                            "(host: %s, path type: %s)",
+                            candidate_host,
+                            candidate_path_type,
+                        )
+                        continue
+                    except httpx.HTTPStatusError as err:
+                        status_code = getattr(
+                            getattr(err, "response", None), "status_code", "unknown"
+                        )
+                        _LOGGER.warning(
+                            "Could not fetch NIU last-track image candidate "
+                            "(host: %s, path type: %s): HTTP %s",
+                            candidate_host,
+                            candidate_path_type,
+                            status_code,
+                        )
+                        continue
+                    except httpx.RequestError:
+                        _LOGGER.warning(
+                            "Could not fetch NIU last-track image candidate "
+                            "(host: %s, path type: %s): request failed",
+                            candidate_host,
+                            candidate_path_type,
+                        )
+                        continue
 
-        self._last_image = response.content
-        self._last_url = last_track_url
+                    content_type = (
+                        response.headers.get("content-type", "")
+                        .partition(";")[0]
+                        .strip()
+                        .lower()
+                    )
+                    if content_type and not content_type.startswith("image/"):
+                        _LOGGER.warning(
+                            "NIU last-track thumbnail returned invalid content type: %s",
+                            content_type,
+                        )
+                        continue
+                    if not response.content:
+                        _LOGGER.warning(
+                            "NIU last-track thumbnail returned an empty response"
+                        )
+                        continue
+
+                    detected_content_type = _detect_image_content_type(response.content)
+                    if detected_content_type is None:
+                        _LOGGER.warning(
+                            "NIU last-track thumbnail returned invalid image data: %s",
+                            _invalid_image_description(response.content),
+                        )
+                        continue
+
+                    self.content_type = detected_content_type
+                    self._last_image = response.content
+                    self._last_url = last_track_url
+                    self._failed_url = None
+                    self._failure_retry_at = 0.0
+                    _LOGGER.debug(
+                        "Fetched NIU last-track thumbnail (%d bytes, %s)",
+                        len(response.content),
+                        detected_content_type,
+                    )
+                    return self._last_image
+        except TimeoutError:
+            _LOGGER.warning(
+                "Timed out while fetching NIU last-track thumbnail candidates"
+            )
+        except asyncio.CancelledError:
+            self._failed_url = last_track_url
+            self._failure_retry_at = monotonic() + IMAGE_FAILURE_RETRY_INTERVAL
+            raise
+
+        self._failed_url = last_track_url
+        self._failure_retry_at = monotonic() + IMAGE_FAILURE_RETRY_INTERVAL
         return self._last_image

--- a/tests/unit/ha_stubs.py
+++ b/tests/unit/ha_stubs.py
@@ -67,6 +67,13 @@ class Camera:
 
     def __init__(self) -> None:
         self.hass = None
+        self._attr_is_on = True
+        self.content_type = "image/jpeg"
+
+    @property
+    def is_on(self) -> bool:
+        """Mirror Home Assistant's default camera power state."""
+        return self._attr_is_on
 
 
 class TimeoutException(Exception):

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 from pathlib import Path
 import sys
@@ -11,8 +12,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from tests.unit.ha_stubs import clear_niu_modules, install_homeassistant_stubs
 
-
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+PNG_IMAGE = b"\x89PNG\r\n\x1a\nimage-bytes"
+NIU_IMAGE_FAILURE = b'{"data":null,"desc":"img fail","status":200}'
 
 
 class FakeApi:
@@ -61,7 +63,15 @@ class FakeCoordinator:
 class FakeResponse:
     """Successful still-image response."""
 
-    content = b"image-bytes"
+    def __init__(
+        self,
+        content: bytes = PNG_IMAGE,
+        content_type: str | None = "image/jpeg",
+    ) -> None:
+        self.content = content
+        self.headers = {}
+        if content_type is not None:
+            self.headers["content-type"] = content_type
 
     def raise_for_status(self) -> None:
         return None
@@ -165,8 +175,8 @@ class EntityTest(unittest.IsolatedAsyncioTestCase):
             first = await camera.async_camera_image()
             second = await camera.async_camera_image()
 
-        self.assertEqual(first, b"image-bytes")
-        self.assertEqual(second, b"image-bytes")
+        self.assertEqual(first, PNG_IMAGE)
+        self.assertEqual(second, PNG_IMAGE)
         self.assertEqual(client.get.call_count, 1)
         self.assertEqual(camera._attr_unique_id, "MQi Last Track Camera")
         self.assertEqual(
@@ -174,6 +184,182 @@ class EntityTest(unittest.IsolatedAsyncioTestCase):
             {("niu", "Niu E-scooter")},
         )
         self.assertIsInstance(camera._attr_device_info["model"], str)
+
+    async def test_camera_is_on_before_first_thumbnail_download(self) -> None:
+        """The camera proxy must be usable before its first image request."""
+        camera = self.camera_module.LastTrackCamera(
+            types.SimpleNamespace(), self.coordinator
+        )
+
+        self.assertTrue(camera.is_on)
+
+    async def test_camera_reports_missing_track_thumbnail(self) -> None:
+        """Missing NIU track data should be visible in debug logs."""
+        client = FakeClient()
+        camera = self.camera_module.LastTrackCamera(
+            types.SimpleNamespace(), self.coordinator
+        )
+
+        with (
+            patch.object(self.camera_module, "get_async_client", return_value=client),
+            patch.object(self.camera_module._LOGGER, "debug") as debug,
+        ):
+            image = await camera.async_camera_image()
+
+        self.assertIsNone(image)
+        client.get.assert_not_called()
+        debug.assert_called_once_with("No NIU last-track thumbnail URL available")
+
+    async def test_camera_rejects_non_image_response(self) -> None:
+        """An HTML error document must not be exposed as a camera image."""
+        self.api.getDataTrack = Mock(return_value="https://example.test/track.jpg")
+        client = FakeClient()
+        client.get.return_value = FakeResponse(b"<html>error</html>", "text/html")
+        camera = self.camera_module.LastTrackCamera(
+            types.SimpleNamespace(), self.coordinator
+        )
+
+        with (
+            patch.object(self.camera_module, "get_async_client", return_value=client),
+            patch.object(self.camera_module._LOGGER, "warning") as warning,
+        ):
+            image = await camera.async_camera_image()
+
+        self.assertIsNone(image)
+        warning.assert_called_once_with(
+            "NIU last-track thumbnail returned invalid content type: %s",
+            "text/html",
+        )
+
+    async def test_camera_uses_thumbnail_response_content_type(self) -> None:
+        """Home Assistant should serve the thumbnail with its detected media type."""
+        self.api.getDataTrack = Mock(return_value="https://example.test/track.png")
+        client = FakeClient()
+        client.get.return_value = FakeResponse(PNG_IMAGE, "image/jpeg; charset=binary")
+        camera = self.camera_module.LastTrackCamera(
+            types.SimpleNamespace(), self.coordinator
+        )
+
+        with patch.object(self.camera_module, "get_async_client", return_value=client):
+            image = await camera.async_camera_image()
+
+        self.assertEqual(image, PNG_IMAGE)
+        self.assertEqual(camera.content_type, "image/png")
+
+    async def test_camera_falls_back_after_niu_img_fail_response(self) -> None:
+        """The domestic CDN URL should be tried after NIU's overseas URL fails."""
+        overseas_url = (
+            "https://app-api-fk.niu.com/track/overseas/thumb/ride.png?token=test"
+        )
+        domestic_url = "https://app-api.niucache.com/track/thumb/ride.png?token=test"
+        self.api.getDataTrack = Mock(return_value=overseas_url)
+        client = FakeClient()
+        client.get.side_effect = [
+            FakeResponse(NIU_IMAGE_FAILURE, "image/png"),
+            FakeResponse(PNG_IMAGE, "image/png"),
+        ]
+        camera = self.camera_module.LastTrackCamera(
+            types.SimpleNamespace(), self.coordinator
+        )
+
+        with (
+            patch.object(self.camera_module, "get_async_client", return_value=client),
+            patch.object(self.camera_module._LOGGER, "warning") as warning,
+        ):
+            image = await camera.async_camera_image()
+
+        self.assertEqual(image, PNG_IMAGE)
+        self.assertEqual(
+            [call.args[0] for call in client.get.await_args_list],
+            [overseas_url, domestic_url],
+        )
+        warning.assert_called_once_with(
+            "NIU last-track thumbnail returned invalid image data: %s",
+            "NIU status 200: img fail",
+        )
+
+    def test_camera_builds_fallbacks_for_unknown_niu_cdn_host(self) -> None:
+        """A new NIU CDN hostname should still use the known track path fallbacks."""
+        source_url = "https://cdn-new.niu.test/track/thumb/ride.png?token=test"
+
+        candidates = self.camera_module._thumbnail_url_candidates(source_url)
+
+        self.assertEqual(candidates[0], source_url)
+        self.assertIn(
+            "https://app-api.niucache.com/track/thumb/ride.png?token=test",
+            candidates,
+        )
+        self.assertIn(
+            "https://app-api-fk.niu.com/track/overseas/thumb/ride.png?token=test",
+            candidates,
+        )
+
+    def test_camera_prefers_verified_domestic_paths_for_niu_gateway(self) -> None:
+        """The working domestic thumbnail path must precede overseas fallbacks."""
+        source_url = (
+            "https://s.niucache.com/app-api-fk/v5/track/overseas/thumb/"
+            "TEST-SN/test-ride/image.png?token=test"
+        )
+
+        candidates = self.camera_module._thumbnail_url_candidates(source_url)
+
+        self.assertEqual(
+            candidates,
+            [
+                "https://s.niucache.com/app-api-fk/v5/track/thumb/"
+                "TEST-SN/test-ride/image.png?token=test",
+                source_url,
+                "https://app-api-fk.niu.com/v5/track/thumb/"
+                "TEST-SN/test-ride/image.png?token=test",
+                "https://app-api-fk.niu.com/v5/track/overseas/thumb/"
+                "TEST-SN/test-ride/image.png?token=test",
+            ],
+        )
+
+    async def test_camera_throttles_retries_after_invalid_image(self) -> None:
+        """Repeated proxy requests must not repeatedly hit a failing NIU URL."""
+        self.api.getDataTrack = Mock(return_value="https://example.test/track.png")
+        client = FakeClient()
+        client.get.return_value = FakeResponse(NIU_IMAGE_FAILURE, "image/png")
+        camera = self.camera_module.LastTrackCamera(
+            types.SimpleNamespace(), self.coordinator
+        )
+
+        with (
+            patch.object(self.camera_module, "get_async_client", return_value=client),
+            patch.object(self.camera_module, "monotonic", side_effect=[100, 100, 110]),
+            patch.object(self.camera_module._LOGGER, "warning") as warning,
+        ):
+            first = await camera.async_camera_image()
+            second = await camera.async_camera_image()
+
+        self.assertIsNone(first)
+        self.assertIsNone(second)
+        client.get.assert_awaited_once()
+        warning.assert_called_once_with(
+            "NIU last-track thumbnail returned invalid image data: %s",
+            "NIU status 200: img fail",
+        )
+
+    async def test_camera_rejects_empty_image_response(self) -> None:
+        """An empty CDN response must not replace a usable camera image."""
+        self.api.getDataTrack = Mock(return_value="https://example.test/track.jpg")
+        client = FakeClient()
+        client.get.return_value = FakeResponse(b"")
+        camera = self.camera_module.LastTrackCamera(
+            types.SimpleNamespace(), self.coordinator
+        )
+
+        with (
+            patch.object(self.camera_module, "get_async_client", return_value=client),
+            patch.object(self.camera_module._LOGGER, "warning") as warning,
+        ):
+            image = await camera.async_camera_image()
+
+        self.assertIsNone(image)
+        warning.assert_called_once_with(
+            "NIU last-track thumbnail returned an empty response"
+        )
 
     async def test_camera_preserves_cached_image_after_timeout(self) -> None:
         """A transient image failure must not discard the last valid thumbnail."""
@@ -198,10 +384,79 @@ class EntityTest(unittest.IsolatedAsyncioTestCase):
             first = await camera.async_camera_image()
             after_timeout = await camera.async_camera_image()
 
-        self.assertEqual(first, b"image-bytes")
-        self.assertEqual(after_timeout, b"image-bytes")
+        self.assertEqual(first, PNG_IMAGE)
+        self.assertEqual(after_timeout, PNG_IMAGE)
         self.assertEqual(client.get.call_count, 2)
         warning.assert_called_once()
+
+    async def test_camera_limits_total_fallback_time_and_throttles_retry(
+        self,
+    ) -> None:
+        """A hanging CDN must finish before HA's proxy timeout and start backoff."""
+        self.api.getDataTrack = Mock(
+            return_value="https://example.test/track/overseas/thumb/ride.png"
+        )
+        client = FakeClient()
+
+        async def never_finishes(*args, **kwargs):
+            await asyncio.sleep(1)
+
+        client.get.side_effect = never_finishes
+        camera = self.camera_module.LastTrackCamera(
+            types.SimpleNamespace(), self.coordinator
+        )
+
+        with (
+            patch.object(self.camera_module, "get_async_client", return_value=client),
+            patch.object(self.camera_module, "GET_IMAGE_TOTAL_TIMEOUT", 0.01),
+            patch.object(self.camera_module, "monotonic", side_effect=[100, 100, 110]),
+            patch.object(self.camera_module._LOGGER, "warning") as warning,
+        ):
+            first = await camera.async_camera_image()
+            second = await camera.async_camera_image()
+
+        self.assertIsNone(first)
+        self.assertIsNone(second)
+        client.get.assert_awaited_once()
+        warning.assert_called_once_with(
+            "Timed out while fetching NIU last-track thumbnail candidates"
+        )
+
+    async def test_camera_does_not_log_private_thumbnail_url_on_http_error(
+        self,
+    ) -> None:
+        """HTTP failures must not expose scooter or ride identifiers in logs."""
+        private_url = (
+            "https://s.niucache.com/app-api-fk/v5/track/overseas/thumb/"
+            "PRIVATE-SERIAL/PRIVATE-RIDE/image.png"
+        )
+        self.api.getDataTrack = Mock(return_value=private_url)
+        client = FakeClient()
+        error = self.camera_module.httpx.HTTPStatusError(
+            f"not found for URL {private_url}"
+        )
+        error.response = types.SimpleNamespace(status_code=404)
+        client.get.side_effect = error
+        camera = self.camera_module.LastTrackCamera(
+            types.SimpleNamespace(), self.coordinator
+        )
+
+        with (
+            patch.object(self.camera_module, "get_async_client", return_value=client),
+            patch.object(self.camera_module._LOGGER, "warning") as warning,
+        ):
+            image = await camera.async_camera_image()
+
+        self.assertIsNone(image)
+        log_output = " ".join(str(call) for call in warning.call_args_list)
+        self.assertNotIn("PRIVATE-SERIAL", log_output)
+        self.assertNotIn("PRIVATE-RIDE", log_output)
+        self.assertTrue(
+            any(
+                "HTTP %s" in call.args[0] and call.args[-1] == 404
+                for call in warning.call_args_list
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Describe your changes

> [!IMPORTANT]
> This is a stacked PR. It depends on #76 and should be merged after #76.
>
> It is a sibling of #77, not a dependency of #77. Both branches are based directly on `fix/coordinated-api-polling`, so either sibling can be reviewed and merged independently after #76.
>
> The branch contains exactly one additional commit relative to `fix/coordinated-api-polling`. Because this PR intentionally targets `master`, GitHub will also show the changes inherited from #75 and #76 until those PRs are merged.

This PR makes the last-track camera return a valid still image to Home Assistant and handles the incompatible thumbnail URLs observed in real NIU responses.

The previous camera path could successfully set up the entity while returning empty image data. NIU may also provide an overseas thumbnail URL that responds with HTTP 200 but contains a small JSON `img fail` payload instead of an image. Home Assistant then repeatedly requested the camera proxy and displayed a placeholder or HTTP 500 response.

This change:

- implements the entity directly as a Home Assistant still-image `Camera` while preserving its previous unique ID;
- fetches thumbnails with Home Assistant's shared asynchronous HTTP client;
- supports known domestic, overseas, gateway, cache, and direct NIU thumbnail URL variants;
- prioritizes the verified domestic path for the NIU gateway response shape;
- validates image signatures instead of trusting HTTP 200 or a misleading response header;
- rejects empty, JSON, HTML, and otherwise invalid image bodies;
- detects and exposes the actual PNG/JPEG/GIF/WebP/BMP/SVG content type;
- caps each request and the complete fallback sequence so Home Assistant's camera proxy does not hang;
- caches the last valid image and avoids re-downloading an unchanged URL;
- throttles retries after failures to prevent rapid repeated NIU requests;
- keeps cancellation behavior correct during Home Assistant shutdown/reload; and
- avoids writing private scooter or ride identifiers to warning logs.

No integration version bump is needed for manual installation or for this PR. The entity identity is retained, so existing dashboard cards continue to reference the same camera.

### Stack position

1. #75 ? API session recovery and robust HTTP errors
2. #76 ? coordinated polling and legacy BatteryCharge compatibility
3. #77 ? IsCharging metadata compatibility (sibling; not required by this PR)
4. **This PR #78 last-track camera rendering**

### Validation

- `python -m unittest discover -s tests/unit -p "test_*.py" -v`
- 31 cumulative unit tests pass on this branch.
- The incremental diff contains one commit relative to #76 and no changes from #77.
- Focused tests cover URL candidate ordering, domestic fallback after NIU `img fail`, empty/non-image rejection, content-type detection, timeout budgeting, retry throttling, cancellation, caching, missing track data, and redaction of private URL identifiers.
- Candidate URL variants were also checked directly against the real NIU response path: the domestic gateway and direct domestic endpoint returned the same valid PNG, while failing variants returned JSON or HTTP errors as covered by the fallback logic.
- Practical Home Assistant testing confirmed that the camera now renders and downloads the map image for the latest real ride instead of showing the placeholder.

## Issue ticket number and link

Depends on #76 ? please merge #76 first. This transitively depends on #75.
Should also resolve #74 and resolve #72 

There is no dedicated upstream issue for the empty/invalid thumbnail response reproduced here. The earlier camera setup issue #68 provides related background, but this PR addresses the subsequent image-fetching and NIU URL-compatibility failure:

- https://github.com/marcelwestrahome/home-assistant-niu-component/pull/68

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics? No; camera success and fallback behavior are locally observable and require no telemetry.
- [x] Will this be part of a product update? No separate product announcement is required; the user-facing release note could be: "Restore last-track camera maps across NIU thumbnail URL variants."
