### PR TITLE
Add local Home Assistant test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ With the thanks to pikka97 !!!
 ![config flow](images/config_flow_niu_integration.png)
 4. Enjoy your new NIU integration :-)
 
+## Local test environment
+
+See [podman/README.md](podman/README.md) for a local Home Assistant environment
+with a simulated NIU API.
+
 ## Known bugs
 
 some people had problems with this version please take the latest 1.o  versions

--- a/podman/.gitignore
+++ b/podman/.gitignore
@@ -1,0 +1,3 @@
+.env
+ha-config/
+*.tar

--- a/podman/README.md
+++ b/podman/README.md
@@ -1,0 +1,88 @@
+# Local Home Assistant test environment
+
+This environment runs the official Home Assistant image together with a small
+NIU API simulator. It never contacts a real NIU account.
+
+Every start copies `../custom_components/niu` from the current working tree into
+the Home Assistant configuration volume. The preparation container changes only
+the two NIU base URLs in that generated copy so they point to the mock server.
+The integration source in the working tree is neither changed nor replaced, so
+the environment always tests the code currently checked out in the repository.
+
+## Requirements
+
+- Podman with a running Podman machine on Windows or macOS
+- a Compose provider such as `podman-compose`
+
+Install `podman-compose` once for the current Python installation if no Compose
+provider is available yet:
+
+```console
+python -m pip install podman-compose
+```
+
+## Start
+
+From this directory, run:
+
+```console
+podman compose up --build
+```
+
+Open <http://localhost:8123> and complete Home Assistant's onboarding on the
+first run. In the Home Assistant UI, open **Settings > Devices & services**, click
+**Add Integration**, search for **NIU**, and select it. The mock accepts any NIU
+username and password. It exposes two vehicles with distinct names, serial
+numbers, and sensor values, including one dual-battery and one single-battery
+payload. Use the vehicle selection offered by the checked-out integration version
+to test that it consistently uses the chosen vehicle.
+
+The Home Assistant configuration is kept in the `niu-ha-config` volume. Running
+`podman compose down` stops the environment without deleting it. Run `podman
+compose up --build` again after changing the integration source.
+
+The mock API is available locally on <http://localhost:8080>. Keep its endpoints
+and response fields in sync whenever the integration starts using additional NIU
+data. Unknown paths return HTTP 404 so accidentally missing mock responses remain
+visible.
+
+## Optional baseline backup
+
+A baseline archive is useful for restoring an already-onboarded local instance,
+but it must not be committed: it contains authentication state, installation IDs,
+logs, and database contents.
+
+**Never export the volume while Home Assistant is running.** Home Assistant may
+still have SQLite database and write-ahead-log files open, which can produce an
+inconsistent baseline. The Compose configuration gives Home Assistant up to 60
+seconds for a graceful shutdown. Wait until `podman compose down` has completed
+before running the export command:
+
+```console
+podman compose down
+podman volume export --output "/path/to/niu-ha-baseline.tar" niu-ha-config
+```
+
+Restore the archive into a newly created volume, leaving any existing test volume
+untouched:
+
+```console
+podman volume create niu-ha-restored
+podman volume import niu-ha-restored "/path/to/niu-ha-baseline.tar"
+```
+
+Select that volume before starting the environment. In PowerShell:
+
+```powershell
+$env:HA_CONFIG_VOLUME = "niu-ha-restored"
+podman compose up --build
+```
+
+In a POSIX shell:
+
+```sh
+HA_CONFIG_VOLUME=niu-ha-restored podman compose up --build
+```
+
+Do not publish the archive or use real Home Assistant or NIU credentials in this
+test environment.

--- a/podman/compose.yaml
+++ b/podman/compose.yaml
@@ -1,0 +1,35 @@
+services:
+  prepare:
+    image: ${HA_IMAGE:-ghcr.io/home-assistant/home-assistant:stable}
+    entrypoint: ["python3", "/prepare.py"]
+    volumes:
+      - ha-config:/config
+      - ../custom_components/niu:/source:ro
+      - ./prepare.py:/prepare.py:ro
+
+  mock-niu:
+    build:
+      context: ./mock-niu
+      args:
+        HA_IMAGE: ${HA_IMAGE:-ghcr.io/home-assistant/home-assistant:stable}
+    ports:
+      - "127.0.0.1:8080:8080"
+
+  homeassistant:
+    image: ${HA_IMAGE:-ghcr.io/home-assistant/home-assistant:stable}
+    stop_grace_period: 60s
+    depends_on:
+      prepare:
+        condition: service_completed_successfully
+      mock-niu:
+        condition: service_started
+    environment:
+      TZ: ${TZ:-UTC}
+    ports:
+      - "127.0.0.1:8123:8123"
+    volumes:
+      - ha-config:/config
+
+volumes:
+  ha-config:
+    name: ${HA_CONFIG_VOLUME:-niu-ha-config}

--- a/podman/mock-niu/Containerfile
+++ b/podman/mock-niu/Containerfile
@@ -1,0 +1,6 @@
+ARG HA_IMAGE=ghcr.io/home-assistant/home-assistant:stable
+FROM ${HA_IMAGE}
+
+COPY server.py /server.py
+
+ENTRYPOINT ["python3", "/server.py"]

--- a/podman/mock-niu/server.py
+++ b/podman/mock-niu/server.py
@@ -1,0 +1,206 @@
+"""Small NIU API simulator for the local Home Assistant environment."""
+
+import base64
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import sys
+from urllib.parse import parse_qs, urlsplit
+
+
+TRACK_IMAGE = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+TOKEN_RESPONSE = {
+    "status": 0,
+    "data": {
+        "token": {
+            "access_token": "local-access-token",
+            "refresh_token": "local-refresh-token",
+            "expires_in": 86400,
+        }
+    },
+}
+
+VEHICLES = {
+    "LOCAL-NIU-001": {
+        "scooter_name": "Mock NIU One",
+        "/v3/motor_data/battery_info": {
+            "batteries": {
+                "compartmentA": {
+                    "bmsId": "MOCK-BMS-A1",
+                    "batteryCharging": 78,
+                    "isConnected": True,
+                    "chargedTimes": 42,
+                    "temperatureDesc": "Normal",
+                    "temperature": 21,
+                    "gradeBattery": 96,
+                },
+                "compartmentB": {
+                    "bmsId": "MOCK-BMS-B1",
+                    "batteryCharging": 64,
+                    "isConnected": True,
+                    "chargedTimes": 39,
+                    "temperatureDesc": "Normal",
+                    "temperature": 22,
+                    "gradeBattery": 94,
+                },
+            }
+        },
+        "/v5/scooter/motor_data/index_info": {
+            "nowSpeed": 0,
+            "isConnected": True,
+            "isCharging": False,
+            "lockStatus": True,
+            "leftTime": 0,
+            "estimatedMileage": 58,
+            "centreCtrlBattery": 91,
+            "lastTrack": {"distance": 4200, "ridingTime": 900},
+            "postion": {"lng": 13.6167, "lat": 47.6422},
+        },
+        "/motoinfo/overallTally": {"totalMileage": 1234.5, "bindDaysCount": 365},
+        "/v5/track/list/v2": [
+            {
+                "startTime": 1788253200000,
+                "endTime": 1788254100000,
+                "distance": 4200,
+                "avespeed": 16.8,
+                "ridingtime": 900,
+                "track_thumb": "http://mock-niu:8080/track.png",
+            }
+        ],
+    },
+    "LOCAL-NIU-002": {
+        "scooter_name": "Mock NIU Two",
+        "/v3/motor_data/battery_info": {
+            "batteries": {
+                "compartmentA": {
+                    "batteryCharging": 54,
+                    "isConnected": True,
+                    "chargedTimes": 17,
+                    "temperatureDesc": "Warm",
+                    "temperature": 24,
+                    "gradeBattery": 88,
+                }
+            }
+        },
+        "/v5/scooter/motor_data/index_info": {
+            "nowSpeed": 23,
+            "isConnected": True,
+            "isCharging": False,
+            "lockStatus": False,
+            "leftTime": 0,
+            "estimatedMileage": 36,
+            "centreCtrlBattery": 84,
+            "lastTrack": {"distance": 8100, "ridingTime": 1200},
+            "postion": {"lng": 16.3738, "lat": 48.2082},
+        },
+        "/motoinfo/overallTally": {"totalMileage": 543.2, "bindDaysCount": 120},
+        "/v5/track/list/v2": [
+            {
+                "startTime": 1788339600000,
+                "endTime": 1788340800000,
+                "distance": 8100,
+                "avespeed": 24.3,
+                "ridingtime": 1200,
+                "track_thumb": "http://mock-niu:8080/track.png",
+            }
+        ],
+    },
+}
+
+
+def request_serial_number(url: str, body: bytes, content_type: str) -> str | None:
+    values: dict[str, object] = parse_qs(urlsplit(url).query)
+    if body:
+        try:
+            if content_type.partition(";")[0] == "application/json":
+                decoded = json.loads(body)
+                if isinstance(decoded, dict):
+                    values.update(decoded)
+            else:
+                values.update(parse_qs(body.decode()))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+
+    serial_number = values.get("sn")
+    if isinstance(serial_number, list):
+        return serial_number[-1]
+    return serial_number if isinstance(serial_number, str) else None
+
+
+def response_for(path: str, serial_number: str | None = None) -> dict | None:
+    if path == "/v3/api/oauth2/token":
+        return TOKEN_RESPONSE
+    if path == "/v5/scooter/list":
+        return {
+            "status": 0,
+            "data": {
+                "items": [
+                    {"sn_id": sn, "scooter_name": vehicle["scooter_name"]}
+                    for sn, vehicle in VEHICLES.items()
+                ]
+            },
+        }
+
+    vehicle = VEHICLES.get(serial_number)
+    data = vehicle.get(path) if vehicle else None
+    return {"status": 0, "data": data} if data is not None else None
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _respond(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else b""
+
+        path = urlsplit(self.path).path
+        if path == "/track.png":
+            self.send_response(200)
+            self.send_header("Content-Type", "image/png")
+            self.send_header("Content-Length", str(len(TRACK_IMAGE)))
+            self.end_headers()
+            self.wfile.write(TRACK_IMAGE)
+            return
+
+        payload = response_for(
+            path,
+            request_serial_number(
+                self.path, body, self.headers.get("Content-Type", "")
+            ),
+        )
+        status = 200 if payload is not None else 404
+        body = json.dumps(payload or {"status": 404, "desc": "unknown mock endpoint"}).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    do_GET = _respond
+    do_POST = _respond
+
+
+def self_test() -> None:
+    assert TRACK_IMAGE.startswith(b"\x89PNG\r\n\x1a\n")
+    vehicles = response_for("/v5/scooter/list")["data"]["items"]
+    assert [vehicle["sn_id"] for vehicle in vehicles] == list(VEHICLES)
+    first = response_for("/v3/motor_data/battery_info", "LOCAL-NIU-001")
+    second = response_for("/v3/motor_data/battery_info", "LOCAL-NIU-002")
+    assert first["data"]["batteries"]["compartmentA"]["batteryCharging"] == 78
+    assert first["data"]["batteries"]["compartmentB"]["batteryCharging"] == 64
+    assert second["data"]["batteries"]["compartmentA"]["batteryCharging"] == 54
+    assert "compartmentB" not in second["data"]["batteries"]
+    assert response_for("/v3/motor_data/battery_info", "UNKNOWN") is None
+    assert request_serial_number("/?sn=LOCAL-NIU-001", b"", "") == "LOCAL-NIU-001"
+    assert request_serial_number("/", b"sn=LOCAL-NIU-002", "") == "LOCAL-NIU-002"
+    assert (
+        request_serial_number("/", b'{"sn":"LOCAL-NIU-002"}', "application/json")
+        == "LOCAL-NIU-002"
+    )
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        self_test()
+    else:
+        ThreadingHTTPServer(("0.0.0.0", 8080), Handler).serve_forever()

--- a/podman/prepare.py
+++ b/podman/prepare.py
@@ -1,0 +1,35 @@
+"""Copy the current integration into Home Assistant and point it at the mock."""
+
+from pathlib import Path
+import shutil
+import sys
+
+
+REAL_URLS = (
+    "https://account-fk.niu.com",
+    "https://app-api-fk.niu.com",
+)
+
+
+def prepare(source: Path, target: Path, mock_url: str) -> None:
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target)
+
+    constants = target / "const.py"
+    text = constants.read_text(encoding="utf-8")
+    for real_url in REAL_URLS:
+        if real_url not in text:
+            raise RuntimeError(f"Expected NIU URL not found: {real_url}")
+        text = text.replace(real_url, mock_url)
+    constants.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    prepare(
+        Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/source"),
+        Path(sys.argv[2])
+        if len(sys.argv) > 2
+        else Path("/config/custom_components/niu"),
+        sys.argv[3] if len(sys.argv) > 3 else "http://mock-niu:8080",
+    )


### PR DESCRIPTION
## Summary

- add a "Podman Compose" environment based on the official Home Assistant image
- copy the integration from the current working tree into an isolated HA config volume
- rewrite only the copied integration's NIU API URLs to use the local mock service
- add a dependency-free NIU API mock with two distinct vehicles
- document onboarding, startup, shutdown and baseline export/import
- link the development setup from the main README
- exclude local environment files, HA configuration and baseline archives from Git

## Design and safety

- no mock-specific switches are added to the production code
- no credentials or Home Assistant baseline data are committed
- the mock uses Python's standard library and the already required Home Assistant image
- Home Assistant is stopped gracefully before exporting its configuration volume

## Testing

- 39 unit tests passed after rebasing onto the current upstream master
- mock API self-test passed
- Podman Compose environment started successfully
- Home Assistant communicated with both mocked vehicles
- clean shutdown, export, import and restart workflow tested