### PR TITLE
Add multi-vehicle selection and stable device identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ With the thanks to pikka97 !!!
 ## Setup
 1. In Home Assistant's settings under "device and services" click on the "Add integration" button.
 2. Search for "NIU" and click on it.
-3. Enter your NIU account credentials and select the sensors you want to add.
-![config flow](images/config_flow_niu_integration.png)
-4. Enjoy your new NIU integration :-)
+3. Enter the NIU account email and password.
+4. Select a vehicle by name and serial number, then select the sensors you want to add.
+5. To add another vehicle, add the NIU integration again and repeat these steps. The same NIU account credentials can be used for multiple vehicles.
+6. Enjoy your new NIU integration :-)
 
 ## Known bugs
 

--- a/custom_components/niu/__init__.py
+++ b/custom_components/niu/__init__.py
@@ -5,6 +5,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from .api import NiuApi
 from .const import (
@@ -18,6 +19,7 @@ from .const import (
 from .coordinator import NiuDataUpdateCoordinator, required_sensor_groups
 
 _LOGGER = logging.getLogger(__name__)
+LEGACY_DEVICE_IDENTIFIER = (DOMAIN, "Niu E-scooter")
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
@@ -42,6 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         niu_auth[CONF_USERNAME],
         niu_auth[CONF_PASSWORD],
         niu_auth[CONF_SCOOTER_ID],
+        entry.unique_id,
     )
     coordinator = NiuDataUpdateCoordinator(
         hass,
@@ -59,12 +62,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if entry_updates:
         hass.config_entries.async_update_entry(entry, **entry_updates)
 
+    _migrate_device_identifier(hass, entry, str(api.sn))
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(
         entry, _get_platforms(sensors_selected)
     )
 
     return True
+
+
+def _migrate_device_identifier(
+    hass: HomeAssistant, entry: ConfigEntry, serial_number: str
+) -> None:
+    """Replace the old shared device identifier without orphaning its entities."""
+    registry = dr.async_get(hass)
+    if hasattr(registry, "async_get_device_by_identifier"):
+        legacy_device = registry.async_get_device_by_identifier(
+            LEGACY_DEVICE_IDENTIFIER, entry.entry_id
+        )
+    else:
+        legacy_device = registry.async_get_device(
+            identifiers={LEGACY_DEVICE_IDENTIFIER}
+        )
+        if legacy_device and entry.entry_id not in legacy_device.config_entries:
+            return
+
+    if legacy_device is not None:
+        registry.async_update_device(
+            legacy_device.id,
+            new_identifiers={(DOMAIN, serial_number)},
+        )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/niu/api.py
+++ b/custom_components/niu/api.py
@@ -74,11 +74,15 @@ class NiuResponseError(NiuApiError):
 
 
 class NiuVehicleNotFoundError(NiuApiError):
-    """The selected vehicle index does not exist in the NIU account."""
+    """The selected vehicle does not exist in the NIU account."""
 
-    def __init__(self, scooter_id: int) -> None:
-        super().__init__(f"NIU vehicle index {scooter_id} does not exist")
-        self.scooter_id = scooter_id
+    def __init__(self, vehicle: int | str) -> None:
+        super().__init__(f"NIU vehicle {vehicle} does not exist")
+        self.vehicle = vehicle
+
+
+class NiuNoVehiclesError(NiuApiError):
+    """The NIU account does not contain any vehicles."""
 
 
 class NiuApi:
@@ -89,10 +93,12 @@ class NiuApi:
         scooter_id,
         language="en-US",
         timezone="UTC",
+        vehicle_sn=None,
     ) -> None:
         self.username = username
         self.password = password
         self.scooter_id = int(scooter_id)
+        self.vehicle_sn = str(vehicle_sn) if vehicle_sn else None
         self.language = language
         self.timezone = timezone
 
@@ -110,7 +116,7 @@ class NiuApi:
         self.sensor_prefix = ""
 
     @classmethod
-    def from_hass(cls, hass, username, password, scooter_id):
+    def from_hass(cls, hass, username, password, scooter_id, vehicle_sn=None):
         """Create NiuApi with locale settings from Home Assistant config."""
         language = hass.config.language
         # Only append country if language is a bare code (e.g. "en"),
@@ -121,12 +127,17 @@ class NiuApi:
             username,
             password,
             scooter_id,
+            vehicle_sn=vehicle_sn,
             language=language,
             timezone=str(hass.config.time_zone),
         )
 
     def initialize(self):
         """Authenticate and load vehicle metadata without polling entity data."""
+        self.select_vehicle(self.get_vehicles(), self.vehicle_sn)
+
+    def get_vehicles(self):
+        """Authenticate and return the vehicles available to the account."""
         self.get_token()
         vehicles = self.get_vehicles_info(MOTOINFO_LIST_API_URI)
         try:
@@ -136,11 +147,35 @@ class NiuApi:
 
         if not isinstance(items, list):
             raise NiuResponseError("NIU vehicle list has an unexpected format")
-        if self.scooter_id < 0 or self.scooter_id >= len(items):
-            raise NiuVehicleNotFoundError(self.scooter_id)
+        if not items:
+            raise NiuNoVehiclesError("No vehicles found in the NIU account")
+        if any(
+            not isinstance(vehicle, dict)
+            or not vehicle.get("sn_id")
+            or not vehicle.get("scooter_name")
+            for vehicle in items
+        ):
+            raise NiuResponseError("NIU vehicle list has an unexpected format")
+        return items
+
+    def select_vehicle(self, items, vehicle_sn=None):
+        """Select a vehicle by serial number, falling back to its legacy index."""
+        if vehicle_sn is not None:
+            try:
+                scooter_id = next(
+                    index
+                    for index, vehicle in enumerate(items)
+                    if str(vehicle.get("sn_id")) == str(vehicle_sn)
+                )
+            except StopIteration as err:
+                raise NiuVehicleNotFoundError(vehicle_sn) from err
+        else:
+            scooter_id = self.scooter_id
+            if scooter_id < 0 or scooter_id >= len(items):
+                raise NiuVehicleNotFoundError(scooter_id)
 
         try:
-            vehicle = items[self.scooter_id]
+            vehicle = items[scooter_id]
             sn = vehicle["sn_id"]
             scooter_name = vehicle["scooter_name"]
         except (KeyError, TypeError) as err:
@@ -148,7 +183,9 @@ class NiuApi:
         if not sn or not scooter_name:
             raise NiuResponseError("NIU vehicle list has an unexpected format")
 
+        self.scooter_id = scooter_id
         self.sn = str(sn)
+        self.vehicle_sn = self.sn
         self.sensor_prefix = str(scooter_name)
 
     def get_token(self):

--- a/custom_components/niu/camera.py
+++ b/custom_components/niu/camera.py
@@ -11,6 +11,7 @@ from urllib.parse import urlsplit, urlunsplit
 import httpx
 
 from homeassistant.components.camera import Camera
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import DOMAIN
@@ -119,7 +120,21 @@ def _invalid_image_description(content: bytes) -> str:
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     """Set up the last-track camera from a config entry."""
     coordinator: NiuDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    _migrate_unique_id(hass, entry.entry_id, coordinator.data)
     async_add_entities([LastTrackCamera(hass, coordinator)])
+
+
+def _migrate_unique_id(hass, entry_id: str, api) -> None:
+    """Replace the name-based camera ID for this config entry."""
+    registry = er.async_get(hass)
+    unique_id = f"camera.niu_scooter_{api.sn}_last_track"
+    for entity in er.async_entries_for_config_entry(registry, entry_id):
+        if (
+            entity.domain == "camera"
+            and entity.platform == DOMAIN
+            and entity.unique_id != unique_id
+        ):
+            registry.async_update_entity(entity.entity_id, new_unique_id=unique_id)
 
 
 class LastTrackCamera(NiuCoordinatorEntity, Camera):
@@ -131,8 +146,7 @@ class LastTrackCamera(NiuCoordinatorEntity, Camera):
         self.hass = hass
         self._api = coordinator.data
         self._attr_name = f"{self._api.sensor_prefix} Last Track Camera"
-        # Preserve GenericCamera's previous identifier to avoid a duplicate entity.
-        self._attr_unique_id = self._attr_name
+        self._attr_unique_id = f"camera.niu_scooter_{self._api.sn}_last_track"
         self._attr_is_streaming = False
         self._last_url: str | None = None
         self._last_image: bytes | None = None

--- a/custom_components/niu/config_flow.py
+++ b/custom_components/niu/config_flow.py
@@ -15,6 +15,7 @@ from .api import (
     NiuAuthenticationError,
     NiuConnectionError,
     NiuHttpError,
+    NiuNoVehiclesError,
     NiuRateLimitError,
     NiuResponseError,
     NiuServerError,
@@ -27,6 +28,7 @@ from .const import (
     CONF_SCOOTER_ID,
     CONF_SENSORS,
     CONF_USERNAME,
+    CONF_VEHICLE,
     DEFAULT_SCOOTER_ID,
     DOMAIN,
 )
@@ -39,16 +41,6 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): selector.TextSelector(
             selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
         ),
-        vol.Required(CONF_SCOOTER_ID, default=DEFAULT_SCOOTER_ID): vol.All(
-            vol.Coerce(int), vol.Range(min=0)
-        ),
-        vol.Required(CONF_SENSORS, default=AVAILABLE_SENSORS): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=AVAILABLE_SENSORS,
-                multiple=True,
-                mode=selector.SelectSelectorMode.LIST,
-            ),
-        ),
     }
 )
 
@@ -58,10 +50,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._api: NiuApi | None = None
+        self._vehicles: list[dict[str, Any]] = []
+        self._credentials: dict[str, Any] = {}
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Validate credentials and the selected vehicle before creating an entry."""
+        """Validate credentials and load vehicles from the configured NIU account."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -70,11 +68,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self.hass,
                     user_input[CONF_USERNAME],
                     user_input[CONF_PASSWORD],
-                    user_input[CONF_SCOOTER_ID],
+                    DEFAULT_SCOOTER_ID,
                 )
-                await self.hass.async_add_executor_job(api.initialize)
+                vehicles = await self.hass.async_add_executor_job(api.get_vehicles)
             except NiuAuthenticationError:
                 errors["base"] = "invalid_auth"
+            except NiuNoVehiclesError:
+                errors["base"] = "no_vehicles"
             except (NiuConnectionError, NiuServerError, NiuRateLimitError):
                 errors["base"] = "cannot_connect"
             except NiuVehicleNotFoundError:
@@ -85,25 +85,66 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected error while validating NIU account")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(str(api.sn))
+                self._api = api
+                self._vehicles = vehicles
+                self._credentials = user_input
+                return await self.async_step_vehicle()
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_vehicle(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select a vehicle returned for the configured NIU account."""
+        if self._api is None or not self._vehicles:
+            return await self.async_step_user()
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            vehicle_sn = user_input[CONF_VEHICLE]
+            try:
+                self._api.select_vehicle(self._vehicles, vehicle_sn)
+            except NiuVehicleNotFoundError:
+                errors["base"] = "invalid_scooter"
+            else:
+                await self.async_set_unique_id(str(self._api.sn))
                 self._abort_if_unique_id_configured()
-                title = (
-                    f"NIU – {api.sensor_prefix}"
-                    if api.sensor_prefix
-                    else "NIU vehicle"
-                )
                 return self.async_create_entry(
-                    title=title,
+                    title=f"NIU – {self._api.sensor_prefix}",
                     data={
                         CONF_AUTH: {
-                            CONF_USERNAME: user_input[CONF_USERNAME],
-                            CONF_PASSWORD: user_input[CONF_PASSWORD],
-                            CONF_SCOOTER_ID: user_input[CONF_SCOOTER_ID],
+                            **self._credentials,
+                            CONF_SCOOTER_ID: self._api.scooter_id,
                             CONF_SENSORS: user_input[CONF_SENSORS],
                         }
                     },
                 )
 
+        options = [
+            {
+                "value": str(vehicle.get("sn_id")),
+                "label": f"{vehicle.get('scooter_name')} ({vehicle.get('sn_id')})",
+            }
+            for vehicle in self._vehicles
+        ]
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_VEHICLE): selector.SelectSelector(
+                    selector.SelectSelectorConfig(options=options)
+                ),
+                vol.Required(
+                    CONF_SENSORS, default=AVAILABLE_SENSORS
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=AVAILABLE_SENSORS,
+                        multiple=True,
+                        mode=selector.SelectSelectorMode.LIST,
+                    ),
+                ),
+            }
+        )
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="vehicle", data_schema=schema, errors=errors
         )

--- a/custom_components/niu/const.py
+++ b/custom_components/niu/const.py
@@ -12,6 +12,7 @@ DOMAIN = "niu"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_SCOOTER_ID = "scooter_id"
+CONF_VEHICLE = "vehicle"
 CONF_AUTH = "conf_auth"
 CONF_SENSORS = "sensors_selected"
 

--- a/custom_components/niu/entity.py
+++ b/custom_components/niu/entity.py
@@ -14,10 +14,10 @@ class NiuCoordinatorEntity(CoordinatorEntity[NiuDataUpdateCoordinator]):
 
     def __init__(self, coordinator: NiuDataUpdateCoordinator) -> None:
         super().__init__(coordinator)
-        device_name = "Niu E-scooter"
+        api = coordinator.data
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_name)},
-            name=device_name,
+            identifiers={(DOMAIN, str(api.sn))},
+            name=api.sensor_prefix,
             manufacturer="NIU",
-            model="E-scooter",
+            model="Vehicle",
         )

--- a/custom_components/niu/translations/en.json
+++ b/custom_components/niu/translations/en.json
@@ -6,20 +6,26 @@
         "error": {
             "cannot_connect": "Unable to connect to NIU. Please try again later.",
             "invalid_auth": "The email address or password is incorrect.",
-            "invalid_scooter": "The selected vehicle index does not exist.",
+            "invalid_scooter": "The selected vehicle is no longer available in the NIU account.",
+            "no_vehicles": "No vehicles were found in the NIU account.",
             "unknown": "NIU returned an unexpected response. Please try again later."
         },
         "step": {
             "user": {
                 "data": {
                     "username": "NIU account email",
-                    "password": "Password",
-                    "scooter_id": "Vehicle index",
+                    "password": "Password"
+                },
+                "data_description": {
+                    "username": "Email address used to sign in to the NIU account being configured."
+                }
+            },
+            "vehicle": {
+                "data": {
+                    "vehicle": "Vehicle",
                     "sensors_selected": "Sensors"
                 },
                 "data_description": {
-                    "username": "Email address used to sign in to your NIU account.",
-                    "scooter_id": "Zero-based position of the vehicle in your NIU account (0 selects the first vehicle).",
                     "sensors_selected": "Select the sensors to add to Home Assistant."
                 }
             }

--- a/tests/unit/ha_stubs.py
+++ b/tests/unit/ha_stubs.py
@@ -144,6 +144,16 @@ def install_homeassistant_stubs() -> None:
     helpers.__path__ = []
     device_registry = types.ModuleType("homeassistant.helpers.device_registry")
     device_registry.DeviceInfo = DeviceInfo
+    device_registry.async_get = lambda hass: hass.device_registry
+    entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    entity_registry.async_get = lambda hass: hass.entity_registry
+    entity_registry.async_entries_for_config_entry = (
+        lambda registry, entry_id: [
+            entity
+            for entity in registry.entries
+            if entity.config_entry_id == entry_id
+        ]
+    )
     httpx_client = types.ModuleType("homeassistant.helpers.httpx_client")
     httpx_client.get_async_client = lambda hass, verify_ssl=True: None
     selector = types.ModuleType("homeassistant.helpers.selector")
@@ -174,6 +184,7 @@ def install_homeassistant_stubs() -> None:
         "homeassistant.core": core,
         "homeassistant.helpers": helpers,
         "homeassistant.helpers.device_registry": device_registry,
+        "homeassistant.helpers.entity_registry": entity_registry,
         "homeassistant.helpers.httpx_client": httpx_client,
         "homeassistant.helpers.selector": selector,
         "homeassistant.helpers.update_coordinator": update_coordinator,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -390,6 +390,40 @@ class NiuApiTest(unittest.TestCase):
         self.assertEqual(headers["Accept-Language"], "zh-CN")
         self.assertIn("clientIdentifier=Domestic", headers["user-agent"])
 
+    def test_initialize_prefers_serial_number_over_changed_list_order(self) -> None:
+        """An existing entry must keep its vehicle when NIU reorders the list."""
+        api_module.requests.post.return_value = token_response("access")
+        api_module.requests.get.return_value = FakeResponse(
+            200,
+            {
+                "status": 0,
+                "data": {
+                    "items": [
+                        {"sn_id": "OTHER-SN", "scooter_name": "Other"},
+                        {"sn_id": "TEST-SN", "scooter_name": "Electric moped"},
+                    ]
+                },
+            },
+        )
+        self.api.scooter_id = 0
+        self.api.vehicle_sn = "TEST-SN"
+
+        self.api.initialize()
+
+        self.assertEqual(self.api.scooter_id, 1)
+        self.assertEqual(self.api.sn, "TEST-SN")
+        self.assertEqual(self.api.sensor_prefix, "Electric moped")
+
+    def test_get_vehicles_reports_empty_account(self) -> None:
+        """An account without vehicles should have a specific setup error."""
+        api_module.requests.post.return_value = token_response("access")
+        api_module.requests.get.return_value = FakeResponse(
+            200, {"status": 0, "data": {"items": []}}
+        )
+
+        with self.assertRaises(api_module.NiuNoVehiclesError):
+            self.api.get_vehicles()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_component.py
+++ b/tests/unit/test_component.py
@@ -61,12 +61,29 @@ class FakeConfigEntries:
         return True
 
 
+class FakeDeviceRegistry:
+    """Record legacy device identifier migrations."""
+
+    def __init__(self, legacy_device=None) -> None:
+        self.legacy_device = legacy_device
+        self.updated: list[tuple[str, dict]] = []
+
+    def async_get_device_by_identifier(self, identifier, config_entry_id):
+        if identifier == ("niu", "Niu E-scooter"):
+            return self.legacy_device
+        return None
+
+    def async_update_device(self, device_id, **changes) -> None:
+        self.updated.append((device_id, changes))
+
+
 class FakeHass:
     """Home Assistant subset used during config-entry setup."""
 
     def __init__(self) -> None:
         self.data = {}
         self.config_entries = FakeConfigEntries()
+        self.device_registry = FakeDeviceRegistry()
         self.config = types.SimpleNamespace(
             language="de",
             country="AT",
@@ -154,6 +171,38 @@ class ComponentTest(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(await self.component.async_setup_entry(hass, entry))
 
         self.assertEqual(hass.config_entries.updated, [])
+
+    async def test_setup_migrates_legacy_device_to_vehicle_serial(self) -> None:
+        """The old shared identifier should become the selected vehicle serial."""
+        auth = {
+            self.const.CONF_USERNAME: "user@example.com",
+            self.const.CONF_PASSWORD: "secret",
+            self.const.CONF_SCOOTER_ID: 0,
+            self.const.CONF_SENSORS: ["BatteryChargeA"],
+        }
+        entry = types.SimpleNamespace(
+            entry_id="entry-1",
+            data={self.const.CONF_AUTH: auth},
+            unique_id="TEST-SN",
+            title="Electric moped",
+        )
+        hass = FakeHass()
+        hass.device_registry.legacy_device = types.SimpleNamespace(id="legacy-device")
+
+        with patch.object(
+            self.component.NiuApi, "from_hass", return_value=FakeApi()
+        ):
+            self.assertTrue(await self.component.async_setup_entry(hass, entry))
+
+        self.assertEqual(
+            hass.device_registry.updated,
+            [
+                (
+                    "legacy-device",
+                    {"new_identifiers": {(self.const.DOMAIN, "TEST-SN")}},
+                )
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -7,7 +7,7 @@ import types
 import unittest
 from unittest.mock import Mock, patch
 
-from tests.unit.ha_stubs import clear_niu_modules, install_homeassistant_stubs
+from tests.unit.ha_stubs import AbortFlow, clear_niu_modules, install_homeassistant_stubs
 
 
 class FakeHass:
@@ -24,13 +24,26 @@ class FakeHass:
 
 
 class FakeApi:
-    """Successfully initialized NIU API object."""
-
-    sn = "TEST-SN"
-    sensor_prefix = "Flotti"
+    """Successfully authenticated NIU API object with two vehicles."""
 
     def __init__(self) -> None:
-        self.initialize = Mock()
+        self.vehicles = [
+            {"sn_id": "FIRST-SN", "scooter_name": "Electric moped"},
+            {"sn_id": "SECOND-SN", "scooter_name": "Commuter"},
+        ]
+        self.get_vehicles = Mock(return_value=self.vehicles)
+        self.scooter_id = 0
+        self.sn = None
+        self.sensor_prefix = ""
+
+    def select_vehicle(self, vehicles, vehicle_sn) -> None:
+        for index, vehicle in enumerate(vehicles):
+            if vehicle["sn_id"] == vehicle_sn:
+                self.scooter_id = index
+                self.sn = vehicle_sn
+                self.sensor_prefix = vehicle["scooter_name"]
+                return
+        raise self.api_module.NiuVehicleNotFoundError(vehicle_sn)
 
 
 class ConfigFlowTest(unittest.IsolatedAsyncioTestCase):
@@ -44,30 +57,68 @@ class ConfigFlowTest(unittest.IsolatedAsyncioTestCase):
         self.const = importlib.import_module("custom_components.niu.const")
         self.flow = self.flow_module.ConfigFlow()
         self.flow.hass = FakeHass()
-        self.user_input = {
+        FakeApi.api_module = self.api_module
+        self.credentials = {
             self.const.CONF_USERNAME: "user@example.com",
             self.const.CONF_PASSWORD: "secret",
-            self.const.CONF_SCOOTER_ID: 0,
+        }
+        self.vehicle_input = {
+            self.const.CONF_VEHICLE: "SECOND-SN",
             self.const.CONF_SENSORS: ["BatteryChargeA", "CurrentSpeed"],
         }
 
-    async def test_success_validates_vehicle_and_creates_unique_entry(self) -> None:
-        """Setup should validate the selected vehicle before saving credentials."""
+    async def test_success_lists_vehicles_and_creates_selected_entry(self) -> None:
+        """Setup should offer account vehicles and save the selected index."""
         api = FakeApi()
 
         with patch.object(
             self.flow_module.NiuApi, "from_hass", return_value=api
         ) as from_hass:
-            result = await self.flow.async_step_user(self.user_input)
+            vehicle_form = await self.flow.async_step_user(self.credentials)
+            result = await self.flow.async_step_vehicle(self.vehicle_input)
 
-        api.initialize.assert_called_once_with()
+        api.get_vehicles.assert_called_once_with()
         from_hass.assert_called_once_with(
             self.flow.hass, "user@example.com", "secret", 0
         )
-        self.assertEqual(self.flow.unique_id, "TEST-SN")
+        self.assertEqual(vehicle_form["type"], "form")
+        self.assertEqual(vehicle_form["step_id"], "vehicle")
+        options = vehicle_form["data_schema"][self.const.CONF_VEHICLE]["options"]
+        self.assertEqual(
+            options,
+            [
+                {
+                    "value": "FIRST-SN",
+                    "label": "Electric moped (FIRST-SN)",
+                },
+                {"value": "SECOND-SN", "label": "Commuter (SECOND-SN)"},
+            ],
+        )
+        self.assertEqual(self.flow.unique_id, "SECOND-SN")
         self.assertEqual(result["type"], "create_entry")
-        self.assertEqual(result["title"], "NIU – Flotti")
-        self.assertEqual(result["data"], {self.const.CONF_AUTH: self.user_input})
+        self.assertEqual(result["title"], "NIU – Commuter")
+        self.assertEqual(
+            result["data"],
+            {
+                self.const.CONF_AUTH: {
+                    **self.credentials,
+                    self.const.CONF_SCOOTER_ID: 1,
+                    self.const.CONF_SENSORS: self.vehicle_input[
+                        self.const.CONF_SENSORS
+                    ],
+                }
+            },
+        )
+
+    async def test_same_vehicle_cannot_be_configured_twice(self) -> None:
+        """A serial number already used by another entry must be rejected."""
+        api = FakeApi()
+        self.flow.hass.configured_unique_ids.add("SECOND-SN")
+
+        with patch.object(self.flow_module.NiuApi, "from_hass", return_value=api):
+            await self.flow.async_step_user(self.credentials)
+            with self.assertRaises(AbortFlow):
+                await self.flow.async_step_vehicle(self.vehicle_input)
 
     async def test_api_failures_are_reported_precisely(self) -> None:
         """Authentication, transport, and vehicle errors need different messages."""
@@ -76,6 +127,7 @@ class ConfigFlowTest(unittest.IsolatedAsyncioTestCase):
             (self.api_module.NiuConnectionError("offline"), "cannot_connect"),
             (self.api_module.NiuServerError(503), "cannot_connect"),
             (self.api_module.NiuRateLimitError(60), "cannot_connect"),
+            (self.api_module.NiuNoVehiclesError("empty account"), "no_vehicles"),
             (self.api_module.NiuVehicleNotFoundError(2), "invalid_scooter"),
             (self.api_module.NiuResponseError("bad response"), "unknown"),
         )
@@ -83,11 +135,11 @@ class ConfigFlowTest(unittest.IsolatedAsyncioTestCase):
         for failure, expected_error in failures:
             with self.subTest(failure=type(failure).__name__):
                 api = FakeApi()
-                api.initialize.side_effect = failure
+                api.get_vehicles.side_effect = failure
                 with patch.object(
                     self.flow_module.NiuApi, "from_hass", return_value=api
                 ):
-                    result = await self.flow.async_step_user(self.user_input)
+                    result = await self.flow.async_step_user(self.credentials)
 
                 self.assertEqual(result["type"], "form")
                 self.assertEqual(result["errors"], {"base": expected_error})
@@ -95,13 +147,13 @@ class ConfigFlowTest(unittest.IsolatedAsyncioTestCase):
     async def test_unexpected_failure_is_logged_and_reported(self) -> None:
         """Unexpected defects must remain visible in logs without breaking the flow."""
         api = FakeApi()
-        api.initialize.side_effect = RuntimeError("boom")
+        api.get_vehicles.side_effect = RuntimeError("boom")
 
         with (
             patch.object(self.flow_module.NiuApi, "from_hass", return_value=api),
             self.assertLogs(self.flow_module._LOGGER, level="ERROR"),
         ):
-            result = await self.flow.async_step_user(self.user_input)
+            result = await self.flow.async_step_user(self.credentials)
 
         self.assertEqual(result["errors"], {"base": "unknown"})
 

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -84,6 +84,25 @@ class FakeClient:
         self.get = AsyncMock(return_value=FakeResponse())
 
 
+class FakeEntityRegistry:
+    """Entity registry subset used for camera ID migration."""
+
+    def __init__(self, config_entry_id="entry-1") -> None:
+        self.entries = [
+            types.SimpleNamespace(
+                config_entry_id=config_entry_id,
+                domain="camera",
+                platform="niu",
+                unique_id="MQi Last Track Camera",
+                entity_id="camera.mqi_last_track_camera",
+            )
+        ]
+        self.updated = []
+
+    def async_update_entity(self, entity_id, **changes) -> None:
+        self.updated.append((entity_id, changes))
+
+
 class EntityTest(unittest.IsolatedAsyncioTestCase):
     """Verify entities consume only coordinator-cached state."""
 
@@ -128,8 +147,9 @@ class EntityTest(unittest.IsolatedAsyncioTestCase):
         self.api.updateBat.assert_not_called()
         self.assertEqual(
             sensor_a._attr_device_info["identifiers"],
-            {("niu", "Niu E-scooter")},
+            {("niu", "TEST-SN")},
         )
+        self.assertEqual(sensor_a._attr_device_info["name"], "MQi")
         self.assertIsInstance(sensor_a._attr_device_info["model"], str)
         self.assertEqual(sensor_a._attr_device_info, sensor_b._attr_device_info)
 
@@ -198,12 +218,49 @@ class EntityTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(first, PNG_IMAGE)
         self.assertEqual(second, PNG_IMAGE)
         self.assertEqual(client.get.call_count, 1)
-        self.assertEqual(camera._attr_unique_id, "MQi Last Track Camera")
+        self.assertEqual(
+            camera._attr_unique_id, "camera.niu_scooter_TEST-SN_last_track"
+        )
         self.assertEqual(
             camera._attr_device_info["identifiers"],
-            {("niu", "Niu E-scooter")},
+            {("niu", "TEST-SN")},
         )
         self.assertIsInstance(camera._attr_device_info["model"], str)
+
+    async def test_camera_migrates_legacy_unique_id_for_its_config_entry(self) -> None:
+        """A legacy camera should retain its entity through the serial-ID change."""
+        entry = types.SimpleNamespace(entry_id="entry-1")
+        registry = FakeEntityRegistry()
+        hass = types.SimpleNamespace(
+            data={self.const.DOMAIN: {entry.entry_id: self.coordinator}},
+            entity_registry=registry,
+        )
+        async_add_entities = Mock()
+
+        await self.camera_module.async_setup_entry(hass, entry, async_add_entities)
+
+        self.assertEqual(
+            registry.updated,
+            [
+                (
+                    "camera.mqi_last_track_camera",
+                    {"new_unique_id": "camera.niu_scooter_TEST-SN_last_track"},
+                )
+            ],
+        )
+        camera = async_add_entities.call_args.args[0][0]
+        self.assertEqual(
+            camera._attr_unique_id, "camera.niu_scooter_TEST-SN_last_track"
+        )
+
+    def test_camera_does_not_migrate_another_config_entry(self) -> None:
+        """A same-named camera owned by another entry must not be changed."""
+        registry = FakeEntityRegistry(config_entry_id="another-entry")
+        hass = types.SimpleNamespace(entity_registry=registry)
+
+        self.camera_module._migrate_unique_id(hass, "entry-1", self.api)
+
+        self.assertEqual(registry.updated, [])
 
     async def test_camera_is_on_before_first_thumbnail_download(self) -> None:
         """The camera proxy must be usable before its first image request."""


### PR DESCRIPTION
## Summary

- split the config flow into credential validation and vehicle selection
- list available vehicles by name and serial number
- allow separate config entries for multiple vehicles on the same NIU account
- persist the selected serial number and prefer it over the legacy zero-based index
- use the serial number for config-entry and device identity
- migrate legacy device identifiers
- use serial-based unique IDs for last-track cameras and migrate existing camera entities without changing their entity IDs
- reject duplicate configuration of the same vehicle

## Backward compatibility

- existing entries continue to fall back to the stored scooter index
- existing sensor identities are retained

## Testing

- 43 unit tests passed
- tested in Home Assistant with two mocked NIU vehicles (see PR #80)
- both vehicles added as separate entries
- verified camera entity migration for two mock vehicles in a running Home Assistant instance
- duplicate setup correctly rejected
- both entries reloaded successfully
- values remained assigned to the correct vehicle after a Home Assistant restart